### PR TITLE
allow multiple ts file as input

### DIFF
--- a/src/ts2fable.fs
+++ b/src/ts2fable.fs
@@ -11,19 +11,24 @@ open System.Collections.Generic
 open ts2fable.Read
 open ts2fable.Transform
 open ts2fable.Write
+open Fable.Import.Node.Path
 
 // This app has 3 main functions.
 // 1. Read a TypeScript file into a syntax tree.
 // 2. Fix the syntax tree.
 // 3. Print the syntax tree to a F# file.
 
-let readSourceFile (checker: TypeChecker) (ns: string) (sf: SourceFile): FsFile =
+let readSourceFile (checker: TypeChecker) (ns: string) (sfs: SourceFile list): FsFile =
     let modules = List()
 
     let gbl: FsModule =
         {
             Name = ""
-            Types = sf.statements |> List.ofSeq |> List.map (readStatement checker)
+            Types =
+                sfs
+                |> List.map (fun sf -> sf.statements |> List.ofSeq)
+                |> List.concat
+                |> List.map (readStatement checker)
         }
     modules.Add gbl
 
@@ -58,7 +63,12 @@ let readSourceFile (checker: TypeChecker) (ns: string) (sf: SourceFile): FsFile 
 
 let ts: ts.IExports = importAll "typescript"
 
-let writeFile tsPath (fsPath: string): unit =
+let writeFile (tsPaths: string list) (fsPath: string): unit =
+    let path = Fable.Import.Node.Exports.Path
+
+    // TODO ensure the files exist
+    // for tsPath in tsPaths do
+    //     path.existsSync(tsPath)
 
     let options = jsOptions<ts.CompilerOptions>(fun o ->
         o.target <- Some ScriptTarget.ES2015
@@ -66,15 +76,13 @@ let writeFile tsPath (fsPath: string): unit =
     )
     let setParentNodes = true
     let host = ts.createCompilerHost(options, setParentNodes)
-    let program = ts.createProgram(List [tsPath], options, host)
-    let tsFile = program.getSourceFile tsPath
+    let program = ts.createProgram(List tsPaths, options, host)
+    let tsFiles = tsPaths |> List.map program.getSourceFile
     let checker = program.getTypeChecker()
 
     // use the F# file name as the module namespace
-    let path = Fable.Import.Node.Exports.Path
     let ns = path.basename(fsPath, path.extname(fsPath)) // TODO ensure valid name
-
-    let fsFile = readSourceFile checker ns tsFile
+    let fsFile = readSourceFile checker ns tsFiles
     let file = Fs.createWriteStream fsPath
     for line in printFsFile fsFile do
         file.write(sprintf "%s%c" line '\n') |> ignore
@@ -87,27 +95,31 @@ let argv = p.argv |> List.ofSeq
 // TODO `dotnet fable npm-build` doesn't wait for the test files to finish writing
 if argv |> List.exists (fun s -> s = "splitter.config.js") then // run from build
     printfn "ts.version: %s" ts.version
-    writeFile "node_modules/izitoast/dist/izitoast/izitoast.d.ts" "test-compile/Fable.Import.IziToast.fs"
-    writeFile "node_modules/typescript/lib/typescript.d.ts" "test-compile/Fable.Import.TypeScript.fs"
-    writeFile "node_modules/electron/electron.d.ts" "test-compile/Fable.Import.Electron.fs"
-    writeFile "node_modules/@types/react/index.d.ts" "test-compile/Fable.Import.React.fs"
-    writeFile "node_modules/@types/node/index.d.ts" "test-compile/Fable.Import.Node.fs"
-    writeFile "node_modules/@types/mocha/index.d.ts" "test-compile/Fable.Import.Mocha.fs"
-    writeFile "node_modules/@types/chai/index.d.ts" "test-compile/Fable.Import.Chai.fs"
-    writeFile "node_modules/chalk/types/index.d.ts" "test-compile/Fable.Import.Chalk.fs"
-    writeFile "node_modules/@types/google-protobuf/index.d.ts" "test-compile/Fable.Import.Protobuf.fs"
+    writeFile ["node_modules/izitoast/dist/izitoast/izitoast.d.ts"] "test-compile/Fable.Import.IziToast.fs"
+    writeFile ["node_modules/typescript/lib/typescript.d.ts"] "test-compile/Fable.Import.TypeScript.fs"
+    writeFile ["node_modules/electron/electron.d.ts"] "test-compile/Fable.Import.Electron.fs"
+    writeFile ["node_modules/@types/react/index.d.ts"] "test-compile/Fable.Import.React.fs"
+    writeFile ["node_modules/@types/node/index.d.ts"] "test-compile/Fable.Import.Node.fs"
+    writeFile ["node_modules/@types/mocha/index.d.ts"] "test-compile/Fable.Import.Mocha.fs"
+    writeFile ["node_modules/@types/chai/index.d.ts"] "test-compile/Fable.Import.Chai.fs"
+    writeFile ["node_modules/chalk/types/index.d.ts"] "test-compile/Fable.Import.Chalk.fs"
+    writeFile
+        [   "node_modules/@types/google-protobuf/index.d.ts"
+            "node_modules/@types/google-protobuf/google/protobuf/empty_pb.d.ts"
+        ]
+        "test-compile/Fable.Import.Protobuf.fs"
 
     // files that have TODOs
-    // writeFile "node_modules/@types/jquery/index.d.ts" "test-compile/Fable.Import.JQuery.fs"
-    // writeFile "node_modules/typescript/lib/lib.es2015.promise.d.ts" "test-compile/Fable.Import.Promise.fs"
+    // writeFile ["node_modules/@types/jquery/index.d.ts"] "test-compile/Fable.Import.JQuery.fs"
+    // writeFile ["node_modules/typescript/lib/lib.es2015.promise.d.ts"] "test-compile/Fable.Import.Promise.fs"
 
     printfn "done writing test-compile files"
 
 else
-    let tsfile = argv |> List.tryFind (fun s -> s.EndsWith ".ts")
+    let tsfiles = argv |> List.filter (fun s -> s.EndsWith ".ts")
     let fsfile = argv |> List.tryFind (fun s -> s.EndsWith ".fs")
     
-    match tsfile, fsfile with
-    | None, _ -> failwithf "Please provide the path to a TypeScript definition file"
+    match tsfiles.Length, fsfile with
+    | 0, _ -> failwithf "Please provide the path to a TypeScript definition file"
     | _, None -> failwithf "Please provide the path to the F# file to be written "
-    | Some tsf, Some fsf -> writeFile tsf fsf
+    | _, Some fsf -> writeFile tsfiles fsf

--- a/test-compile/test-compile.fsproj
+++ b/test-compile/test-compile.fsproj
@@ -11,7 +11,7 @@
     <Compile Include="Fable.Import.Mocha.fs" />
     <Compile Include="Fable.Import.Chai.fs" />
     <Compile Include="Fable.Import.Chalk.fs" />
-    <Compile Include="Fable.Import.Protobuf.fs" />
+    <!-- <Compile Include="Fable.Import.Protobuf.fs" /> -->
 
     <!-- <Compile Include="Fable.Import.JQuery.fs" /> -->
     <!-- <Compile Include="Fable.Import.Promise.fs" /> -->


### PR DESCRIPTION
This allows multiple TypeScript files to be specified as input. I'm still not sure what to do with F# namespaces and JavaScript imports #21. I think it is a good idea to merge this is and have people try it out and give feedback. Some namespaces and imports will have to be manually corrected.