### PR TITLE
allow string literal overloads on any param

### DIFF
--- a/src/transform.fs
+++ b/src/transform.fs
@@ -273,6 +273,7 @@ let fixOverloadingOnStringParameters(f: FsFile): FsFile =
                     match asStringLiteral prm.Type with
                     | None ->
                         sprintf "$%d" (i + 1 - !slCount) |> kind.Add
+                        prms.Add prm
                     | Some sl ->
                         incr slCount
                         sprintf "'%s'" sl |> kind.Add

--- a/test-compile/test-compile.fsproj
+++ b/test-compile/test-compile.fsproj
@@ -7,7 +7,7 @@
     <Compile Include="Fable.Import.TypeScript.fs" />
     <!-- <Compile Include="Fable.Import.Electron.fs" /> -->
     <!-- <Compile Include="Fable.Import.React.fs" /> -->
-    <!-- <Compile Include="Fable.Import.Node.fs" /> -->
+    <Compile Include="Fable.Import.Node.fs" />
     <Compile Include="Fable.Import.Mocha.fs" />
     <Compile Include="Fable.Import.Chai.fs" />
     <Compile Include="Fable.Import.Chalk.fs" />


### PR DESCRIPTION
see #103

This makes it:
``` fs
    module resolve =

        type [<AllowNullLiteral>] IExports =
            abstract __promisify__: hostname: string * ?rrtype: U5<string, string, string, string, string> -> Promise<ResizeArray<string>>
            [<Emit "$0.__promisify__($1,'MX')">] abstract __promisify___MX: unit -> Promise<ResizeArray<MxRecord>>
            [<Emit "$0.__promisify__($1,'NAPTR')">] abstract __promisify___NAPTR: unit -> Promise<ResizeArray<NaptrRecord>>
            [<Emit "$0.__promisify__($1,'SOA')">] abstract __promisify___SOA: unit -> Promise<SoaRecord>
            [<Emit "$0.__promisify__($1,'SRV')">] abstract __promisify___SRV: unit -> Promise<ResizeArray<SrvRecord>>
            [<Emit "$0.__promisify__($1,'TXT')">] abstract __promisify___TXT: unit -> Promise<ResizeArray<ResizeArray<string>>>
            abstract __promisify__: hostname: string * ?rrtype: string -> Promise<U6<ResizeArray<string>, ResizeArray<MxRecord>, ResizeArray<NaptrRecord>, SoaRecord, ResizeArray<SrvRecord>, ResizeArray<ResizeArray<string>>>>
```