### PR TITLE
temporarily remove vscode tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "scripts": {
     "build": "fable-splitter -c splitter.config.js",
     "watch": "fable-splitter -c splitter.config.js -w",
-    "test": "fable-splitter -c splitter.test.config.js",
-    "postinstall": "node ./node_modules/vscode/bin/install"
+    "test": "fable-splitter -c splitter.test.config.js"
   },
   "repository": {
     "type": "git",
@@ -57,8 +56,5 @@
     "mocha": "^4.0.1",
     "mocha-appveyor-reporter": "^0.4.0",
     "vscode": "^1.1.8"
-  },
-  "engines": {
-    "vscode": "1.18.1"
   }
 }

--- a/src/ts2fable.fs
+++ b/src/ts2fable.fs
@@ -106,7 +106,7 @@ if argv |> List.exists (fun s -> s = "splitter.config.js") then // run from buil
     writeFile ["node_modules/@types/yargs/index.d.ts"] "test-compile/Yargs.fs"
 
     // for test-compile
-    writeFile ["node_modules/vscode/vscode.d.ts"] "test-compile/VSCode.fs"
+    // writeFile ["node_modules/vscode/vscode.d.ts"] "test-compile/VSCode.fs"
     writeFile ["node_modules/izitoast/dist/izitoast/izitoast.d.ts"] "test-compile/IziToast.fs"
     writeFile ["node_modules/electron/electron.d.ts"] "test-compile/Electron.fs"
     writeFile ["node_modules/@types/react/index.d.ts"] "test-compile/React.fs"

--- a/test-compile/test-compile.fsproj
+++ b/test-compile/test-compile.fsproj
@@ -7,7 +7,7 @@
     <Compile Include="Node.fs" />
     <Compile Include="Yargs.fs" />
 
-    <Compile Include="VSCode.fs" />
+    <!-- <Compile Include="VSCode.fs" /> -->
     <Compile Include="IziToast.fs" />
     <!-- <Compile Include="Electron.fs" /> -->
     <!-- <Compile Include="React.fs" /> -->


### PR DESCRIPTION
to fix  #132

If this fixes it, I'd like to put it back in, but need to figure out how to remove this from package.json
``` js
  "engines": {
    "vscode": "1.18.1"
  }
```