### PR TITLE
Read IndexedAccessType && Extract type literal from union

### DIFF
--- a/src/read.fs
+++ b/src/read.fs
@@ -288,8 +288,8 @@ let rec readTypeNode (checker: TypeChecker) (t: TypeNode): FsType =
         readTypeLiteral checker tl |> FsType.TypeLiteral
     | SyntaxKind.IntersectionType -> simpleType "obj"
     | SyntaxKind.IndexedAccessType ->
-        // function createKeywordTypeNode(kind: KeywordTypeNode["kind"]): KeywordTypeNode;
-        simpleType "obj" // TODO?
+        let ia = t :?> IndexedAccessTypeNode
+        readTypeNode checker ia.objectType
     | SyntaxKind.TypeQuery ->
         // let tq = t :?> TypeQueryNode
         simpleType "obj"

--- a/src/transform.fs
+++ b/src/transform.fs
@@ -811,7 +811,22 @@ let extractTypeLiterals(f: FsFile): FsFile =
                             |> FsType.Interface
 
                         [it2] @ (List.ofSeq newTypes) // append new types
-
+                    | FsType.Alias al -> 
+                        match al.Type with 
+                        | FsType.Union un -> 
+                            let un2 = 
+                                { un with 
+                                    Types = 
+                                        let tps = List<FsType>()
+                                        un.Types |> List.iter(fun tp -> 
+                                            match tp with 
+                                            | FsType.TypeLiteral tl -> tl.Members |> tps.AddRange
+                                            | _ -> tp |> tps.Add
+                                        )
+                                        tps |> List.ofSeq    
+                                }
+                            {al with Type = un2 |> FsType.Union} |> FsType.Alias |> List.singleton 
+                        | _ -> [tp]                       
                     | _ -> [tp]
                 )
             }

--- a/src/write.fs
+++ b/src/write.fs
@@ -70,7 +70,6 @@ let getFsFileOut (fsPath: string) (tsPaths: string list) =
         |> transform
     )
 
-
     {
         // use the F# file name as the module namespace
         // TODO ensure valid name
@@ -83,7 +82,7 @@ let getFsFileOut (fsPath: string) (tsPaths: string list) =
             ]
         Files = fsFiles
     }
-
+    |> fixOpens
 let emitFsFileOut fsPath (fsFileOut: FsFileOut) = 
     emitFsFileOutAsLines fsPath fsFileOut
     |> ignore

--- a/test/fragments/react/f1.d.ts
+++ b/test/fragments/react/f1.d.ts
@@ -1,0 +1,3 @@
+declare namespace React {
+    type Ref<T> = string | { bivarianceHack(instance: T | null): any }["bivarianceHack"];
+}

--- a/test/fragments/react/f1.fs
+++ b/test/fragments/react/f1.fs
@@ -1,0 +1,20 @@
+// ts2fable 0.0.0
+module rec f1
+open System
+open Fable.Core
+open Fable.Import.JS
+
+
+module React =
+
+    type Ref<'T> =
+        U2<string, ('T option -> obj option)>
+
+    [<RequireQualifiedAccess; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+    module Ref =
+        let ofString v: Ref<'T> = v |> U2.Case1
+        let isString (v: Ref<'T>) = match v with U2.Case1 _ -> true | _ -> false
+        let asString (v: Ref<'T>) = match v with U2.Case1 o -> Some o | _ -> None
+        let ofBivarianceHack v: Ref<'T> = v |> U2.Case2
+        let isBivarianceHack (v: Ref<'T>) = match v with U2.Case2 _ -> true | _ -> false
+        let asBivarianceHack (v: Ref<'T>) = match v with U2.Case2 o -> Some o | _ -> None

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -94,12 +94,20 @@ describe "transform tests" <| fun _ ->
             |> equal true
 
     it "multiple ts inputs should export one time" <| fun _ ->
-    let tsPaths =         
-        [   
-            "node_modules/@types/google-protobuf/index.d.ts"
-            "node_modules/@types/google-protobuf/google/protobuf/empty_pb.d.ts"
-        ]
-    let fsPath = "test-compile/Protobuf.fs"
-    testFsFileLines tsPaths fsPath  <| fun lines ->
-        lines.Length < 700
-        |> equal true
+        let tsPaths =         
+            [   
+                "node_modules/@types/google-protobuf/index.d.ts"
+                "node_modules/@types/google-protobuf/google/protobuf/empty_pb.d.ts"
+            ]
+        let fsPath = "test-compile/Protobuf.fs"
+        testFsFileLines tsPaths fsPath  <| fun lines ->
+            lines.Length < 700
+            |> equal true
+
+    it "extract type literal from union" <| fun _ ->
+        let tsPaths = ["test/fragments/react/f1.d.ts"]
+        let fsPath = "test/fragments/react/f1.fs"
+        testFsFiles tsPaths fsPath  <| fun fsFiles ->
+            fsFiles 
+            |> existOnlyOne "bivarianceHack" FsType.isFunction
+            |> equal true

--- a/tools/webpack.config.test.js
+++ b/tools/webpack.config.test.js
@@ -6,7 +6,7 @@ var fs = require('fs');
 console.log("Bundling for test...");
 
 module.exports = {
-  devtool: "source-map",
+  devtool: "inline-source-map",
   entry: common.config.testEntry,
   target: "node",
   externals: common.config.nodeExternals,


### PR DESCRIPTION
### Input:
```typescript
declare namespace React {
    type Ref<T> = string | { bivarianceHack(instance: T | null): any }["bivarianceHack"];
}
```
### Expected behavior:
```fsharp
    type Ref<'T> =
        U2<string, ('T option -> obj option)>
```
### Actual behavior -----This will case compile error
`This construct is deprecated: This type abbreviation has one or more declared type parameters that do not appear in the type being abbreviated. Type abbreviations must use all declared type parameters in the type being abbreviated. Consider removing one or more type parameters, or use a concrete type definition that wraps an underlying type, such as 'type C<'a> = C of ...'.`
```fsharp
    type Ref<'T> =
        U2<string, obj>
```
