### PR TITLE
Add bootstrap fake + update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,15 @@ yarn global add ts2fable@next
 
 **Windows**:
 - `git clone https://github.com/fable-compiler/ts2fable`
-- Install all dependencies: `fake build`
-- In vscode, Press `CTRL+SHIFT+P` run task ---- WatchTest
-- Add your test in `fsfiletest.fs` and prefix it with mocha `only` (See below sample)
+- Install all dependencies: `fake.cmd run build.fsx`
+
+**Unix**:
+- `git clone https://github.com/fable-compiler/ts2fable`
+- `./fake.sh run build.fsx`
+
+**Common to all OS**
+- In vscode, press `Ctrl+Shift+P` > Run Task > WatchTest
+- Add your test in `test/fsFileTests.fs` and prefix it with mocha `only` (See below sample)
 
 Sample Test:
 ```fsharp
@@ -46,15 +52,12 @@ only "duplicated variable exports" <| fun _ ->
     let fsPath = "test-compile/ReactXP.fs"
     testFsFiles tsPaths fsPath  <| fun fsFiles ->
         fsFiles
-        |> getTopVarialbles 
+        |> getTopVarialbles
         |> List.countBy(fun vb -> vb.Name)
         |> List.forall(fun (_,l) -> l = 1)
         |> equal true
 ```
 - Press F5 to debug this test
-
-**Linux**:
-- Help me ----- Please send a PR to this repository
 
 
 ## Conventions
@@ -96,5 +99,3 @@ type Express =
     abstract application: obj with get, set
     [<Emit("$0($1...)")>] abstract Invoke: unit -> Application
 ```
-
-

--- a/dotnet-fake.proj
+++ b/dotnet-fake.proj
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <DotNetCliToolReference Include="dotnet-fake" Version="5.0.0-beta024" />
+  </ItemGroup>
+</Project>

--- a/fake.cmd
+++ b/fake.cmd
@@ -1,0 +1,2 @@
+dotnet restore dotnet-fake.proj
+dotnet fake %*

--- a/fake.sh
+++ b/fake.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+OS=${OS:-"unknown"}
+
+echo $OSTYPE
+if [ "$OS" != "Windows_NT" ]
+then
+  # Allows NETFramework like net45 to be built using dotnet core tooling with mono
+  export FrameworkPathOverride=$(dirname $(which mono))/../lib/mono/4.5/
+fi
+
+dotnet restore dotnet-fake.proj
+dotnet fake $@


### PR DESCRIPTION
@humhei I bootstrapped fake inside the repo otherwise, people need to install it globally and on unix system we don't have the chocolatey equivalent.

I used OS X to build the repo, so I updated the README.md file. In order, to build the repo I needed to run the `Deploy` target so it's install all the dependencies (nuget, npm), restore projects etc.

But from a user perspective it's feel really strange to run `Deploy`. I needed to read the `build.fsx` to make sure was not going to push a version to the server.

I think se should have something like:

```fs
Target.Create "CliTest" Target.DoNothing
Target.Create "Deploy" DoNothing

Target.Create "Setup" Target.DoNothing

"InstallDotNetCore"
    ==> "YarnInstall"
    ==> "Restore"
    ==> "Setup"

"CliTest"
    <== [ "Setup"
          "BuildCli"
          "RunCli"
          "BuildTestCompile" ]

"Deploy"
    <== [ "Setup"
          "BuildTest"
          "RunTest" 
          "CliTest"
          "PushToExports"   //https://github.com/fable-compiler/ts2fable-exports
          "Publish" ]

Target.RunOrDefault "Deploy"
```

Please note, I didn't test this code.

Finally, the README.md show a diff on every line because I think you are on windows and didn't use CRLF as EOF. If needed, we can force that using gitattributes.

I created a PR so we can discuss the different point before merging it :)