### PR TITLE
WIP Rearrange namespace

### DIFF
--- a/src/naming.fs
+++ b/src/naming.fs
@@ -10,6 +10,11 @@ let (|Capital|_|) (letter: string)=
     // Char.IsUpper https://github.com/fable-compiler/Fable/issues/1236
     // if letter.Length = 1 && Char.IsUpper letter.[0] then Some letter else None
 
+
+let (|InvariantEqualI|_|) (str:string) arg = 
+  if String.Compare(str, arg, StringComparison.InvariantCultureIgnoreCase) = 0
+  then Some() else None
+  
 let private digits = [ '0' .. '9' ] |> Seq.map string
 
 let isDigit digit = Seq.contains digit digits

--- a/src/transform.fs
+++ b/src/transform.fs
@@ -1088,3 +1088,23 @@ let extractTypesInGlobalModules  (f: FsFile): FsFile =
             { md with Types = tps |> List.ofSeq }    
         ) 
     }
+
+let rearrageNamespace nameSpace (f: FsFile): FsFile =
+    { f with 
+        Modules = 
+            f.Modules |> List.map(fun md -> 
+                { md with 
+                    Types = 
+                        let tps = List[]
+                        md.Types |> List.iter(fun tp -> 
+                            match tp with 
+                            | FsType.Module md -> 
+                                match escapeWord md.Name with 
+                                | InvariantEqualI nameSpace -> md.Types |> tps.AddRange
+                                | _ -> tp |> tps.Add
+                            | _ -> tp |> tps.Add
+                        )
+                        tps |> List.ofSeq  
+                }
+            )
+    }

--- a/src/write.fs
+++ b/src/write.fs
@@ -20,10 +20,11 @@ open System.Collections.Generic
 // 2. Fix the syntax tree.
 // 3. Print the syntax tree to a F# file.
 
-let transform (file: FsFile): FsFile =
+let transform nameSpace (file: FsFile): FsFile =
     file
     |> removeInternalModules
     |> mergeModulesInFile
+    |> rearrageNamespace nameSpace
     |> aliasToInterfacePartly
     |> extractGenericParameterDefaults
     |> fixTypesHasESKeywords
@@ -64,6 +65,7 @@ let getFsFileOut (fsPath: string) (tsPaths: string list) =
         |> Seq.map (fun sf -> sf.fileName, getJsModuleName sf.fileName)
         |> dict
 
+    let nameSpace = path.basename(fsPath, path.extname(fsPath))
     let fsFiles = tsFiles |> List.map (fun tsFile ->
         {
             FileName = tsFile.fileName
@@ -71,7 +73,7 @@ let getFsFileOut (fsPath: string) (tsPaths: string list) =
             Modules = []
         }
         |> readSourceFile checker tsFile
-        |> transform
+        |> transform nameSpace
     )
 
 
@@ -79,7 +81,7 @@ let getFsFileOut (fsPath: string) (tsPaths: string list) =
     {
         // use the F# file name as the module namespace
         // TODO ensure valid name
-        Namespace = path.basename(fsPath, path.extname(fsPath))
+        Namespace = nameSpace
         Opens =
             [
                 "System"

--- a/test/fragments/react/f8.d.ts
+++ b/test/fragments/react/f8.d.ts
@@ -1,0 +1,3 @@
+declare namespace f8 {
+    type Key = string | number;
+}

--- a/test/fragments/react/f8.fs
+++ b/test/fragments/react/f8.fs
@@ -1,0 +1,18 @@
+// ts2fable 0.0.0
+module rec f8
+open System
+open Fable.Core
+open Fable.Import.JS
+
+
+type Key =
+    U2<string, float>
+
+[<RequireQualifiedAccess; CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module Key =
+    let ofString v: Key = v |> U2.Case1
+    let isString (v: Key) = match v with U2.Case1 _ -> true | _ -> false
+    let asString (v: Key) = match v with U2.Case1 o -> Some o | _ -> None
+    let ofFloat v: Key = v |> U2.Case2
+    let isFloat (v: Key) = match v with U2.Case2 _ -> true | _ -> false
+    let asFloat (v: Key) = match v with U2.Case2 o -> Some o | _ -> None

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -13,7 +13,6 @@ open ts2fable.Transform
 open ts2fable.Print
 open System.Collections.Generic
 open Node
-open Node.Fs
 open ts2fable.Keywords
 
 let [<Global>] describe (msg: string) (f: unit->unit): unit = jsNative
@@ -101,7 +100,7 @@ describe "transform tests" <| fun _ ->
             |> List.countBy(fun vb -> vb.Name)
             |> List.forall(fun (_,l) -> l = 1)
             |> equal true
-
+            
     // https://github.com/fable-compiler/ts2fable/pull/164
     it "multiple ts inputs should export one time" <| fun _ ->
         let tsPaths =         
@@ -185,7 +184,7 @@ describe "transform tests" <| fun _ ->
             |> existOnlyOneByName "ClassType" FsType.isInterface
             |> equal true                                    
 
-    // https://github.com/fable-compiler/ts2fable/issues/182               
+    // https://github.com/fable-compiler/ts2fable/issues/185               
     it "extract type literal from type alias" <| fun _ ->
         let tsPaths = ["test/fragments/react/f7.d.ts"]
         let fsPath = "test/fragments/react/f7.fs"
@@ -196,3 +195,12 @@ describe "transform tests" <| fun _ ->
                     <&&> existOnlyOneByName "bivarianceHack" FsType.isFunction
                 )
             |> equal true                                                
+
+    // https://github.com/fable-compiler/ts2fable/issues/191               
+    it "rearrage namespace" <| fun _ ->
+        let tsPaths = ["test/fragments/react/f8.d.ts"]
+        let fsPath = "test/fragments/react/f8.fs"
+        testFsFiles tsPaths fsPath  <| fun fsFiles ->
+            fsFiles
+            |> existNoneByName "F8" FsType.isModule
+            |> equal true


### PR DESCRIPTION
fix #191 

`createIExports` is partly broken
```fsharp
let [<Import("*","vscode")>] vscode: IExports = jsNative
```
This code was not generated
I think i will fix it tomorrow