### PR TITLE
unwrap options if the parameter itself is optional

### DIFF
--- a/src/bridge.fs
+++ b/src/bridge.fs
@@ -146,6 +146,7 @@ module internal Bridge =
         |> removeDuplicateOptions
         |> extractTypeLiterals // after fixEscapeWords
         |> addAliasUnionHelpers
+        |> removeDuplicateOptionsFromParameters
 
     let getFsFileOut bridge = 
         let program = createProgram bridge


### PR DESCRIPTION
sweet, this seems to work:

![grafik](https://user-images.githubusercontent.com/4236651/52508585-69970e80-2bf5-11e9-8a23-d8f8d803e504.png)

closes https://github.com/fable-compiler/ts2fable/issues/272

ToDo: some unit tests probably. Haven't looked at the test structure