### PR TITLE
add a second pass to 'extractTypeLiterals'

### DIFF
--- a/test/fragments/babylonjs/.gitignore
+++ b/test/fragments/babylonjs/.gitignore
@@ -1,0 +1,2 @@
+*.fs
+!*.expected.fs

--- a/test/fragments/babylonjs/SceneLoader.ImportMeshAsync.d.ts
+++ b/test/fragments/babylonjs/SceneLoader.ImportMeshAsync.d.ts
@@ -1,0 +1,38 @@
+
+
+declare module 'babylonjs' {
+    export = BABYLON;
+}
+
+declare module BABYLON {
+    /** Alias type for value that can be null */
+    type Nullable<T> = T | null;
+}
+
+// dummies
+declare module BABYLON {
+    interface Scene { }
+    interface SceneLoaderProgressEvent { }
+    interface AbstractMesh { }
+    interface IParticleSystem { }
+    interface Skeleton { }
+    interface AnimationGroup { }
+}
+
+
+declare module BABYLON {
+
+    class SceneLoader {
+
+        /** Test:
+         *  1) the callback 'onProgress' should not be Option<Option<_>>. Instead it should be an optional parameter of type function.
+         *  2) the return value should be Promise<Interface>, not Promise<obj>. (Currently it generates 'TypeLiteral_01', would be great if it generated a better-named interface like 'SceneLoaderImportMeshAsyncReturn')
+        */
+        static ImportMeshAsync(meshNames: any, rootUrl: string, sceneFilename?: string, scene?: Nullable<Scene>, onProgress?: Nullable<(event: SceneLoaderProgressEvent) => void>, pluginExtension?: Nullable<string>): Promise<{
+            meshes: AbstractMesh[];
+            particleSystems: IParticleSystem[];
+            skeletons: Skeleton[];
+            animationGroups: AnimationGroup[];
+        }>;
+    }
+}

--- a/test/fragments/babylonjs/SceneLoader.ImportMeshAsync.expected.fs
+++ b/test/fragments/babylonjs/SceneLoader.ImportMeshAsync.expected.fs
@@ -1,0 +1,49 @@
+// ts2fable 0.0.0
+module rec SceneLoader.ImportMeshAsync
+open System
+open Fable.Core
+open Fable.Import.JS
+
+let [<Import("*","test")>] bABYLON: BABYLON.IExports = jsNative
+
+module BABYLON =
+
+    type [<AllowNullLiteral>] IExports =
+        abstract SceneLoader: SceneLoaderStatic
+
+    type Nullable<'T> =
+        'T option
+
+    type [<AllowNullLiteral>] Scene =
+        interface end
+
+    type [<AllowNullLiteral>] SceneLoaderProgressEvent =
+        interface end
+
+    type [<AllowNullLiteral>] AbstractMesh =
+        interface end
+
+    type [<AllowNullLiteral>] IParticleSystem =
+        interface end
+
+    type [<AllowNullLiteral>] Skeleton =
+        interface end
+
+    type [<AllowNullLiteral>] AnimationGroup =
+        interface end
+
+    type [<AllowNullLiteral>] SceneLoader =
+        interface end
+
+    type [<AllowNullLiteral>] SceneLoaderStatic =
+        [<Emit "new $0($1...)">] abstract Create: unit -> SceneLoader
+        /// Test:
+        /// 1) the callback 'onProgress' should not be Option<Option<_>>. Instead it should be an optional parameter of type function.
+        /// 2) the return value should be Promise<Interface>, not Promise<obj>. (Currently it generates 'TypeLiteral_01', would be great if it generated a better-named interface like 'SceneLoaderImportMeshAsyncReturn')
+        abstract ImportMeshAsync: meshNames: obj option * rootUrl: string * ?sceneFilename: string * ?scene: Scene * ?onProgress: (SceneLoaderProgressEvent -> unit) * ?pluginExtension: string -> Promise<TypeLiteral_01>
+
+    type [<AllowNullLiteral>] TypeLiteral_01 =
+        abstract meshes: ResizeArray<AbstractMesh> with get, set
+        abstract particleSystems: ResizeArray<IParticleSystem> with get, set
+        abstract skeletons: ResizeArray<Skeleton> with get, set
+        abstract animationGroups: ResizeArray<AnimationGroup> with get, set

--- a/test/fragments/babylonjs/Stage.PrivateCtor.d.ts
+++ b/test/fragments/babylonjs/Stage.PrivateCtor.d.ts
@@ -1,0 +1,47 @@
+
+
+declare module 'babylonjs' {
+    export = BABYLON;
+}
+
+declare module BABYLON {
+    // dummy
+    interface ISceneComponent { }
+}
+
+
+declare module BABYLON {
+
+    /** this was copy-pasted from babylonjs.
+     * **********
+     * Expected FS output: 'Stage' with 'registerStep' and 'clear', 'StageStatic' with the static Create method
+     * **********
+     * */
+    class Stage<T extends Function> extends Array<{
+        index: number;
+        component: ISceneComponent;
+        action: T;
+    }> {
+        /**
+         * Hide ctor from the rest of the world.
+         * @param items The items to add.
+         */
+        private constructor();
+        /**
+         * Creates a new Stage.
+         * @returns A new instance of a Stage
+         */
+        static Create<T extends Function>(): Stage<T>;
+        /**
+         * Registers a step in an ordered way in the targeted stage.
+         * @param index Defines the position to register the step in
+         * @param component Defines the component attached to the step
+         * @param action Defines the action to launch during the step
+         */
+        registerStep(index: number, component: ISceneComponent, action: T): void;
+        /**
+         * Clears all the steps from the stage.
+         */
+        clear(): void;
+    }
+}

--- a/test/fragments/babylonjs/Stage.PrivateCtor.expected.fs
+++ b/test/fragments/babylonjs/Stage.PrivateCtor.expected.fs
@@ -1,0 +1,42 @@
+// ts2fable 0.0.0
+module rec Stage.PrivateCtor
+open System
+open Fable.Core
+open Fable.Import.JS
+
+let [<Import("*","test")>] bABYLON: BABYLON.IExports = jsNative
+
+module BABYLON =
+
+    type [<AllowNullLiteral>] IExports =
+        abstract Stage: StageStatic
+
+    type [<AllowNullLiteral>] ISceneComponent =
+        interface end
+
+    /// this was copy-pasted from babylonjs.
+    /// **********
+    /// Expected FS output: 'Stage' with 'registerStep' and 'clear', 'StageStatic' with the static Create method
+    /// **********
+    type [<AllowNullLiteral>] Stage<'T> =
+        inherit Array<TypeLiteral_01<'T>>
+        /// <summary>Registers a step in an ordered way in the targeted stage.</summary>
+        /// <param name="index">Defines the position to register the step in</param>
+        /// <param name="component">Defines the component attached to the step</param>
+        /// <param name="action">Defines the action to launch during the step</param>
+        abstract registerStep: index: float * ``component``: ISceneComponent * action: 'T -> unit
+        /// Clears all the steps from the stage.
+        abstract clear: unit -> unit
+
+    /// this was copy-pasted from babylonjs.
+    /// **********
+    /// Expected FS output: 'Stage' with 'registerStep' and 'clear', 'StageStatic' with the static Create method
+    /// **********
+    type [<AllowNullLiteral>] StageStatic =
+        /// Creates a new Stage.
+        abstract Create: unit -> Stage<'T>
+
+    type [<AllowNullLiteral>] TypeLiteral_01<'T> =
+        abstract index: float with get, set
+        abstract ``component``: ISceneComponent with get, set
+        abstract action: 'T with get, set

--- a/test/fragments/regressions/#275-private-members.d.ts
+++ b/test/fragments/regressions/#275-private-members.d.ts
@@ -1,0 +1,37 @@
+
+export module PrivateMembersTests {
+
+    /** No explicit ctor, so an implicit one should be generated */
+    class ImplicitCtor {
+
+    }
+
+    /** explicit paramless ctor, no implicit one should be generated */
+    class ExplicitCtor {
+        constructor();
+    }
+
+    /** explicit ctor, no implicit one should be generated */
+    class ExplicitCtor2 {
+        constructor(i: number);
+    }
+
+    /** explicit private ctor, no ctor should be emitted at all */
+    class PrivateCtor {
+        private constructor(i: number);
+    }
+
+    // ----------------------------
+
+    /** public property named i should be emitted */
+    class PublicField {
+        i : number
+    }
+
+    /** no field should be emitted */
+    class PrivateField {
+        /** this should not be emitted */
+        private i: number
+    }
+}
+

--- a/test/fragments/regressions/#275-private-members.expected.fs
+++ b/test/fragments/regressions/#275-private-members.expected.fs
@@ -1,0 +1,60 @@
+// ts2fable 0.0.0
+module rec #275-private-members
+open System
+open Fable.Core
+open Fable.Import.JS
+
+let [<Import("PrivateMembersTests","test")>] privateMembersTests: PrivateMembersTests.IExports = jsNative
+
+module PrivateMembersTests =
+
+    type [<AllowNullLiteral>] IExports =
+        abstract ImplicitCtor: ImplicitCtorStatic
+        abstract ExplicitCtor: ExplicitCtorStatic
+        abstract ExplicitCtor2: ExplicitCtor2Static
+        abstract PublicField: PublicFieldStatic
+        abstract PrivateField: PrivateFieldStatic
+
+    /// No explicit ctor, so an implicit one should be generated 
+    type [<AllowNullLiteral>] ImplicitCtor =
+        interface end
+
+    /// No explicit ctor, so an implicit one should be generated 
+    type [<AllowNullLiteral>] ImplicitCtorStatic =
+        [<Emit "new $0($1...)">] abstract Create: unit -> ImplicitCtor
+
+    /// explicit paramless ctor, no implicit one should be generated 
+    type [<AllowNullLiteral>] ExplicitCtor =
+        interface end
+
+    /// explicit paramless ctor, no implicit one should be generated 
+    type [<AllowNullLiteral>] ExplicitCtorStatic =
+        [<Emit "new $0($1...)">] abstract Create: unit -> ExplicitCtor
+
+    /// explicit ctor, no implicit one should be generated 
+    type [<AllowNullLiteral>] ExplicitCtor2 =
+        interface end
+
+    /// explicit ctor, no implicit one should be generated 
+    type [<AllowNullLiteral>] ExplicitCtor2Static =
+        [<Emit "new $0($1...)">] abstract Create: i: float -> ExplicitCtor2
+
+    /// explicit private ctor, no ctor should be emitted at all 
+    type [<AllowNullLiteral>] PrivateCtor =
+        interface end
+
+    /// public property named i should be emitted 
+    type [<AllowNullLiteral>] PublicField =
+        abstract i: float with get, set
+
+    /// public property named i should be emitted 
+    type [<AllowNullLiteral>] PublicFieldStatic =
+        [<Emit "new $0($1...)">] abstract Create: unit -> PublicField
+
+    /// no field should be emitted 
+    type [<AllowNullLiteral>] PrivateField =
+        interface end
+
+    /// no field should be emitted 
+    type [<AllowNullLiteral>] PrivateFieldStatic =
+        [<Emit "new $0($1...)">] abstract Create: unit -> PrivateField

--- a/test/fragments/regressions/#277-unwrap-options.d.ts
+++ b/test/fragments/regressions/#277-unwrap-options.d.ts
@@ -37,22 +37,22 @@ export module UnwrapOptionsAlias {
         Foo(p?: Nullable<string>);
 
         /**
-         * The parameter should be "?p : string", NOT "?p : Option<string>"
+         * (DOES NOT YET WORK) The parameter should be "?p : string", NOT "?p : Option<string>"
          */
         Foo2(p?: Nullable<string> | undefined);
 
         /**
-         * The parameter should be "?p : string", NOT "?p : Option<string>"
+         * (DOES NOT YET WORK) The parameter should be "?p : string", NOT "?p : Option<string>"
          */
         Foo3(p?: Nullable<string> | undefined | null);
 
         /** the return value should be Option<string> */
         Bar(): Nullable<string>
 
-        /** the return value should be Option<string> */
+        /** (DOES NOT YET WORK) the return value should be Option<string> */
         Bar2(): Nullable<string> | undefined
 
-        /** the return value should be Option<string> */
+        /** (DOES NOT YET WORK) the return value should be Option<string> */
         Bar3(): Nullable<string> | undefined | null
     }
 }

--- a/test/fragments/regressions/#277-unwrap-options.d.ts
+++ b/test/fragments/regressions/#277-unwrap-options.d.ts
@@ -1,0 +1,58 @@
+
+export module UnwrapOptions {
+    
+    class Class {
+        /**
+         * The parameter should be "?p : string", NOT "?p : Option<string>"
+         */
+        Foo(p?: string | null);
+
+        /**
+         * The parameter should be "?p : string", NOT "?p : Option<string>"
+         */
+        Foo2(p?: string | null | undefined);
+
+        /** the return value should be Option<string> */
+        Bar(): string | null
+
+        /** the return value should be Option<string> */
+        Bar2(): string | null | undefined
+    }
+
+}
+
+export module UnwrapOptionsAlias {
+
+    // this pattern is used by babylonjs
+
+    /** Alias type for value that can be null */
+    type Nullable<T> = T | null;
+
+
+    class Class {
+
+        /**
+         * The parameter should be "?p : string", NOT "?p : Option<string>"
+         */
+        Foo(p?: Nullable<string>);
+
+        /**
+         * The parameter should be "?p : string", NOT "?p : Option<string>"
+         */
+        Foo2(p?: Nullable<string> | undefined);
+
+        /**
+         * The parameter should be "?p : string", NOT "?p : Option<string>"
+         */
+        Foo3(p?: Nullable<string> | undefined | null);
+
+        /** the return value should be Option<string> */
+        Bar(): Nullable<string>
+
+        /** the return value should be Option<string> */
+        Bar2(): Nullable<string> | undefined
+
+        /** the return value should be Option<string> */
+        Bar3(): Nullable<string> | undefined | null
+    }
+}

--- a/test/fragments/regressions/#277-unwrap-options.expected.fs
+++ b/test/fragments/regressions/#277-unwrap-options.expected.fs
@@ -36,15 +36,15 @@ module UnwrapOptionsAlias =
     type [<AllowNullLiteral>] Class =
         /// The parameter should be "?p : string", NOT "?p : Option<string>"
         abstract Foo: ?p: string -> unit
-        /// The parameter should be "?p : string", NOT "?p : Option<string>"
+        /// (DOES NOT YET WORK) The parameter should be "?p : string", NOT "?p : Option<string>"
         abstract Foo2: ?p: Nullable<string> -> unit
-        /// The parameter should be "?p : string", NOT "?p : Option<string>"
+        /// (DOES NOT YET WORK) The parameter should be "?p : string", NOT "?p : Option<string>"
         abstract Foo3: ?p: Nullable<string> -> unit
         /// the return value should be Option<string> 
         abstract Bar: unit -> Nullable<string>
-        /// the return value should be Option<string> 
+        /// (DOES NOT YET WORK) the return value should be Option<string> 
         abstract Bar2: unit -> Nullable<string> option
-        /// the return value should be Option<string> 
+        /// (DOES NOT YET WORK) the return value should be Option<string> 
         abstract Bar3: unit -> Nullable<string> option
 
     type [<AllowNullLiteral>] ClassStatic =

--- a/test/fragments/regressions/#277-unwrap-options.expected.fs
+++ b/test/fragments/regressions/#277-unwrap-options.expected.fs
@@ -1,0 +1,51 @@
+// ts2fable 0.0.0
+module rec #277-unwrap-options
+open System
+open Fable.Core
+open Fable.Import.JS
+
+let [<Import("UnwrapOptions","test")>] unwrapOptions: UnwrapOptions.IExports = jsNative
+let [<Import("UnwrapOptionsAlias","test")>] unwrapOptionsAlias: UnwrapOptionsAlias.IExports = jsNative
+
+module UnwrapOptions =
+
+    type [<AllowNullLiteral>] IExports =
+        abstract Class: ClassStatic
+
+    type [<AllowNullLiteral>] Class =
+        /// The parameter should be "?p : string", NOT "?p : Option<string>"
+        abstract Foo: ?p: string -> unit
+        /// The parameter should be "?p : string", NOT "?p : Option<string>"
+        abstract Foo2: ?p: string -> unit
+        /// the return value should be Option<string> 
+        abstract Bar: unit -> string option
+        /// the return value should be Option<string> 
+        abstract Bar2: unit -> string option
+
+    type [<AllowNullLiteral>] ClassStatic =
+        [<Emit "new $0($1...)">] abstract Create: unit -> Class
+
+module UnwrapOptionsAlias =
+
+    type [<AllowNullLiteral>] IExports =
+        abstract Class: ClassStatic
+
+    type Nullable<'T> =
+        'T option
+
+    type [<AllowNullLiteral>] Class =
+        /// The parameter should be "?p : string", NOT "?p : Option<string>"
+        abstract Foo: ?p: string -> unit
+        /// The parameter should be "?p : string", NOT "?p : Option<string>"
+        abstract Foo2: ?p: Nullable<string> -> unit
+        /// The parameter should be "?p : string", NOT "?p : Option<string>"
+        abstract Foo3: ?p: Nullable<string> -> unit
+        /// the return value should be Option<string> 
+        abstract Bar: unit -> Nullable<string>
+        /// the return value should be Option<string> 
+        abstract Bar2: unit -> Nullable<string> option
+        /// the return value should be Option<string> 
+        abstract Bar3: unit -> Nullable<string> option
+
+    type [<AllowNullLiteral>] ClassStatic =
+        [<Emit "new $0($1...)">] abstract Create: unit -> Class

--- a/test/fragments/regressions/#278-typeliterals-return.d.ts
+++ b/test/fragments/regressions/#278-typeliterals-return.d.ts
@@ -1,0 +1,11 @@
+
+export module TypeLiteralsAsReturnValue {
+    
+    class Class {
+        /**
+         * This should generate two interfaces: 'Class' and 'ClassFooReturn'. The second should have a single property 'i'.
+         */
+        Foo(): { i: number };
+    }
+
+}

--- a/test/fragments/regressions/#278-typeliterals-return.expected.fs
+++ b/test/fragments/regressions/#278-typeliterals-return.expected.fs
@@ -1,0 +1,22 @@
+// ts2fable 0.0.0
+module rec #278-typeliterals-return
+open System
+open Fable.Core
+open Fable.Import.JS
+
+let [<Import("TypeLiteralsAsReturnValue","test")>] typeLiteralsAsReturnValue: TypeLiteralsAsReturnValue.IExports = jsNative
+
+module TypeLiteralsAsReturnValue =
+
+    type [<AllowNullLiteral>] IExports =
+        abstract Class: ClassStatic
+
+    type [<AllowNullLiteral>] Class =
+        /// This should generate two interfaces: 'Class' and 'ClassFooReturn'. The second should have a single property 'i'.
+        abstract Foo: unit -> ClassFooReturn
+
+    type [<AllowNullLiteral>] ClassFooReturn =
+        abstract i: float with get, set
+
+    type [<AllowNullLiteral>] ClassStatic =
+        [<Emit "new $0($1...)">] abstract Create: unit -> Class

--- a/test/fragments/regressions/#288-type-alias-float-number.d.ts
+++ b/test/fragments/regressions/#288-type-alias-float-number.d.ts
@@ -1,0 +1,12 @@
+
+/** it should NOT emit "type float = float" */
+export module TypeAloasFloatNumber {
+
+    /** this pattern is used by babylonjs */
+    type float = number;
+
+    class Class {
+        /** param f and return value should be "float" */
+        Foo(f: float): float;
+    }
+}

--- a/test/fragments/regressions/#288-type-alias-float-number.expected.fs
+++ b/test/fragments/regressions/#288-type-alias-float-number.expected.fs
@@ -1,0 +1,19 @@
+// ts2fable 0.0.0
+module rec #288-type-alias-float-number
+open System
+open Fable.Core
+open Fable.Import.JS
+
+let [<Import("TypeAloasFloatNumber","test")>] typeAloasFloatNumber: TypeAloasFloatNumber.IExports = jsNative
+
+module TypeAloasFloatNumber =
+
+    type [<AllowNullLiteral>] IExports =
+        abstract Class: ClassStatic
+
+    type [<AllowNullLiteral>] Class =
+        /// param f and return value should be "float" 
+        abstract Foo: f: float -> float
+
+    type [<AllowNullLiteral>] ClassStatic =
+        [<Emit "new $0($1...)">] abstract Create: unit -> Class

--- a/test/fragments/regressions/#289-recursive-merge-modules.d.ts
+++ b/test/fragments/regressions/#289-recursive-merge-modules.d.ts
@@ -1,0 +1,16 @@
+declare module 'Outer' {
+    export = Outer;
+}
+
+/** It should generate one module Outer.Inner with two interfaces C1 and C2 */
+declare module Outer.Inner {
+    class C1 {
+
+    }
+}
+
+declare module Outer.Inner {
+    class C2 extends C1 {
+
+    }
+}

--- a/test/fragments/regressions/#289-recursive-merge-modules.expected.fs
+++ b/test/fragments/regressions/#289-recursive-merge-modules.expected.fs
@@ -1,0 +1,27 @@
+// ts2fable 0.0.0
+module rec #289-recursive-merge-modules
+open System
+open Fable.Core
+open Fable.Import.JS
+
+
+module Outer =
+    let [<Import("Inner","test/Outer")>] inner: Inner.IExports = jsNative
+
+    module Inner =
+
+        type [<AllowNullLiteral>] IExports =
+            abstract C1: C1Static
+            abstract C2: C2Static
+
+        type [<AllowNullLiteral>] C1 =
+            interface end
+
+        type [<AllowNullLiteral>] C1Static =
+            [<Emit "new $0($1...)">] abstract Create: unit -> C1
+
+        type [<AllowNullLiteral>] C2 =
+            inherit C1
+
+        type [<AllowNullLiteral>] C2Static =
+            [<Emit "new $0($1...)">] abstract Create: unit -> C2

--- a/test/fragments/regressions/.gitignore
+++ b/test/fragments/regressions/.gitignore
@@ -1,0 +1,2 @@
+*.fs
+!*.expected.fs

--- a/test/test.fsproj
+++ b/test/test.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
@@ -7,6 +7,9 @@
     <Compile Include="functionTests.fs" />
     <Compile Include="fsFileTests.fs" />
     <Compile Include="test.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="fragments\**" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
extract all type literals which hadn't already been extracted by the first pass.

These won't have the same nice names as in the first pass, because the extractor doesn't have enough context (class name, method name, etc), but will instead be named like "TypeLiteral_%02i"

-----------------------

This is a WIP so I can review the ts2fable-exports.

I am currently writing tests 🙃 

-------------------------

fixes https://github.com/fable-compiler/ts2fable/issues/286