### PR TITLE
fix "type float = float" (babylonjs)

### DIFF
--- a/src/bridge.fs
+++ b/src/bridge.fs
@@ -148,6 +148,7 @@ module internal Bridge =
         |> extractTypeLiterals // after fixEscapeWords
         |> addAliasUnionHelpers
         |> removeDuplicateOptionsFromParameters
+        |> fixFloatAlias
 
     let getFsFileOut bridge = 
         let program = createProgram bridge


### PR DESCRIPTION
references https://github.com/fable-compiler/ts2fable/issues/279

![grafik](https://user-images.githubusercontent.com/4236651/53040373-89de8d00-3481-11e9-9064-4729a1e802d7.png)

This removes the compiler error, but keeps double and float