### PR TITLE
Don't convert 'BABYLON' to 'bABYLON'

### DIFF
--- a/src/transform.fs
+++ b/src/transform.fs
@@ -306,12 +306,20 @@ let rec createIExportsModule (ns: string list) (md: FsModule): FsModule * FsVari
         else ns |> String.concat "/"
 
     if typesInIExports.Count > 0 then
+
+        // Some JS names are all uppercase which looks really odd if we just lowercase the first letter
+        let name =
+            if md.Name |> Seq.forall Char.IsUpper then
+                md.Name.ToLower()
+            else
+                md.Name |> lowerFirst
+
         if md.HasDeclare then
             if not <| md.IsNamespace then
                 {
                     Export = { IsGlobal = false; Selector = "*"; Path = path } |> Some
                     HasDeclare = true
-                    Name = md.Name |> lowerFirst
+                    Name = name
                     Type = sprintf "%s.IExports" (fixModuleName md.Name) |> simpleType
                     IsConst = true
                     IsStatic = false
@@ -322,7 +330,7 @@ let rec createIExportsModule (ns: string list) (md: FsModule): FsModule * FsVari
             {
                 Export = { IsGlobal = false; Selector = selector; Path = path } |> Some
                 HasDeclare = true
-                Name = md.Name |> lowerFirst
+                Name = name
                 Type = sprintf "%s.IExports" (fixModuleName md.Name) |> simpleType
                 IsConst = true
                 IsStatic = false

--- a/test/fragments/babylonjs/SceneLoader.ImportMeshAsync.expected.fs
+++ b/test/fragments/babylonjs/SceneLoader.ImportMeshAsync.expected.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Fable.Import.JS
 
-let [<Import("*","test")>] bABYLON: BABYLON.IExports = jsNative
+let [<Import("*","test")>] babylon: BABYLON.IExports = jsNative
 
 module BABYLON =
 

--- a/test/fragments/babylonjs/Stage.PrivateCtor.expected.fs
+++ b/test/fragments/babylonjs/Stage.PrivateCtor.expected.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Fable.Import.JS
 
-let [<Import("*","test")>] bABYLON: BABYLON.IExports = jsNative
+let [<Import("*","test")>] babylon: BABYLON.IExports = jsNative
 
 module BABYLON =
 


### PR DESCRIPTION
bABYLON looked really odd. This changes module names that are all uppercase to all lowercase instead of just lowercasing the first letter.