### PR TITLE
[WIP] Fix importing generic types

### DIFF
--- a/src/bridge.fs
+++ b/src/bridge.fs
@@ -75,6 +75,7 @@ module internal Bridge =
         | Bridge.Web _ -> "moduleName"  
     let private createProgram bridge =
         let createDummy tsPaths (sourceFiles: SourceFile list) =
+            let allFiles = set [ yield! tsPaths; for f in sourceFiles -> f.fileName ]
             let options = jsOptions<CompilerOptions>(fun o ->
                 o.target <- Some scriptTarget
                 o.``module`` <- Some ModuleKind.CommonJS
@@ -87,8 +88,8 @@ module internal Bridge =
                 o.getCanonicalFileName <- id
                 o.getCurrentDirectory <- fun _ -> ""
                 o.getNewLine <- fun _ -> "\r\n"
-                o.fileExists <- fun fileName -> List.contains fileName tsPaths
-                o.readFile <- fun _ -> Some ""
+                o.fileExists <- fun fileName -> allFiles |> Seq.contains fileName
+                o.readFile <- fun _fileName -> Some ""
                 o.directoryExists <- fun _ -> true
                 o.getDirectories <- fun _ -> ResizeArray [] 
             )

--- a/src/node/write.fs
+++ b/src/node/write.fs
@@ -47,13 +47,10 @@ let getFsFileOut (fsPath: string) (tsPaths: string list) (exports: string list) 
 
 
 
-let emitFsFileOutAsLines (fsPath: string) (fsFileOut: FsFileOut) = 
-    let file = fs.createWriteStream (!^fsPath)
-    let lines = List []
-    for line in printFsFile Version.version fsFileOut do
-        lines.Add(line)
-        file.write(sprintf "%s%c" line '\n') |> ignore
-    file.``end``() 
+let emitFsFileOutAsLines (fsPath: string) (fsFileOut: FsFileOut) =
+    let lines = printFsFile Version.version fsFileOut
+    let fullText = lines |> String.concat "\n"
+    fs.writeFileSync(!! fsPath, !! (fullText + "\n"))
     lines |> List.ofSeq
     
 let emitFsFileOut fsPath (fsFileOut: FsFileOut) = 

--- a/src/print.fs
+++ b/src/print.fs
@@ -165,11 +165,12 @@ let rec printModule (lines: ResizeArray<string>) (indent: string) (md: FsModule)
             match imp with
             | FsImport.Type imptp ->
                 let imsp = imptp.ImportSpecifier
+                let tpxs = printTypeParameters imsp.TypeParameters
                 match imsp.PropertyName with 
                 | Some pn ->
-                    sprintf "%stype %s = %s.%s" indent imsp.Name imptp.SpecifiedModule pn |> lines.Add
+                    sprintf "%stype %s%s = %s.%s%s" indent imsp.Name tpxs imptp.SpecifiedModule pn tpxs |> lines.Add
                 | None -> 
-                    sprintf "%stype %s = %s.%s" indent imsp.Name imptp.SpecifiedModule imsp.Name |> lines.Add
+                    sprintf "%stype %s%s = %s.%s%s" indent imsp.Name tpxs imptp.SpecifiedModule imsp.Name tpxs |> lines.Add
             | _ -> ()
         | _ -> ()
 

--- a/src/syntax.fs
+++ b/src/syntax.fs
@@ -184,6 +184,7 @@ type FsImportSpecifier =
     {
         PropertyName: string option
         Name: string
+        TypeParameters: FsType list
     }
 
 type FsTypeImport =

--- a/test/fragments/reactxp/multiple/ReactXP.fs
+++ b/test/fragments/reactxp/multiple/ReactXP.fs
@@ -7,6 +7,7 @@ open Fable.Import.JS
 module ReactXP = __web_ReactXP
 
 module __common_Accessibility =
+    type SubscribableEvent = Subscribableevent.SubscribableEvent
 
     type [<AllowNullLiteral>] IExports =
         abstract Accessibility: AccessibilityStatic

--- a/test/fragments/regressions/#312-import-generics/.gitignore
+++ b/test/fragments/regressions/#312-import-generics/.gitignore
@@ -1,0 +1,5 @@
+# include all
+!*
+
+# exclude actual
+*.actual.fs

--- a/test/fragments/regressions/#312-import-generics/node_modules/test312/core/other.d.ts
+++ b/test/fragments/regressions/#312-import-generics/node_modules/test312/core/other.d.ts
@@ -1,0 +1,2 @@
+declare interface IGenericInterface<T> { value: T }
+export { IGenericInterface }

--- a/test/fragments/regressions/#312-import-generics/node_modules/test312/index.d.ts
+++ b/test/fragments/regressions/#312-import-generics/node_modules/test312/index.d.ts
@@ -1,0 +1,8 @@
+
+import { IGenericInterface } from './core/other';
+
+type IGenericInterfaceAlias<T> = IGenericInterface<T>;
+
+declare function f(a: IGenericInterface<number>, b: IGenericInterfaceAlias<number>);
+
+export { IGenericInterface, IGenericInterfaceAlias, f };

--- a/test/fragments/regressions/#312-import-generics/test312.expected.fs
+++ b/test/fragments/regressions/#312-import-generics/test312.expected.fs
@@ -1,0 +1,18 @@
+// ts2fable 0.0.0
+module rec test312.actual
+open System
+open Fable.Core
+open Fable.Import.JS
+
+type IGenericInterface<'T> = __core_other.IGenericInterface<'T>
+
+type [<AllowNullLiteral>] IExports =
+    abstract f: a: IGenericInterface<float> * b: IGenericInterfaceAlias<float> -> unit
+
+type IGenericInterfaceAlias<'T> =
+    IGenericInterface<'T>
+
+module __core_other =
+
+    type [<AllowNullLiteral>] IGenericInterface<'T> =
+        abstract value: 'T with get, set

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -381,3 +381,17 @@ describe "transform tests" <| fun _ ->
     // https://github.com/fable-compiler/ts2fable/issues/292
     it "regression #292 static props" <| fun _ ->
         runRegressionTest "#292-static-props"
+
+    // https://github.com/fable-compiler/ts2fable/issues/312
+    it "regression #312 import generics" <| fun _ ->
+        // assume cwd is the repository root
+        let originalCwd = Node.``process``.cwd()
+        Node.``process``.chdir(Node.path.join(ResizeArray([originalCwd; "test/fragments/regressions/#312-import-generics"])))
+        try
+            let tsFile = "node_modules/test312/index.d.ts"
+            let fsFile = "test312.actual.fs"
+            ts2fable.node.Write.writeFile [tsFile] fsFile ["test312"]
+            let expectedFsFile = "test312.expected.fs"
+            fileLinesEqual (ts2fable.node.FileSystem.readLines expectedFsFile) (ts2fable.node.FileSystem.readLines fsFile)
+        finally
+            Node.``process``.chdir(originalCwd)


### PR DESCRIPTION
If I have two files where I export and import a generic type

```ts
declare type IGeneric<T> = { value: T };
export { IGeneric }
```

and 

```ts
import { IGeneric } from './#xxx-generic-aliases.2';

type IGenericAlias<T> = IGeneric<T>;

declare function f(a: IGeneric<number>, b: IGenericAlias<number>);

export { IGeneric, IGenericAlias, f };

```

then it currently generates invalid F# code.