### PR TITLE
Fix: web-app stuck at loading

### DIFF
--- a/web-app/webpack.config.js
+++ b/web-app/webpack.config.js
@@ -80,7 +80,7 @@ module.exports = {
                 filename: 'style.[hash].css'
             }),
             new CopyWebpackPlugin([
-                { from: './public' }
+                { from: './output' }
             ]),
             // ensure that we get a production build of any dependencies
             // this is primarily for React, where this removes 179KB from the bundle
@@ -99,7 +99,7 @@ module.exports = {
         ]
     },
     devServer: {
-        contentBase: resolve('./public/'),
+        contentBase: resolve('./output/'),
         publicPath: "/",
         port: 8080,
         hot: true,


### PR DESCRIPTION
`.\fake.cmd run .\build.fsx -t WebApp.Watch` launches a web server serving web-app under `localhost:8080`.  
But: loading that site doesn't work. It just loads forever displaying "We are getting everything ready for you".

JS Console shows: it can't load `require.js`.

Reason: the web-app server serves content from the wrong folder (`public` vs `output`)