### PR TITLE
Fix: ts2fable requires input path with `node_modules`

### DIFF
--- a/test/fragments/babylonjs/SceneLoader.ImportMeshAsync.expected.fs
+++ b/test/fragments/babylonjs/SceneLoader.ImportMeshAsync.expected.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Fable.Core.JS
 
-let [<Import("*","test")>] babylon: BABYLON.IExports = jsNative
+let [<Import("*","SceneLoader.ImportMeshAsync")>] babylon: BABYLON.IExports = jsNative
 
 module BABYLON =
 

--- a/test/fragments/babylonjs/Stage.PrivateCtor.expected.fs
+++ b/test/fragments/babylonjs/Stage.PrivateCtor.expected.fs
@@ -6,7 +6,7 @@ open Fable.Core.JS
 
 type Array<'T> = System.Collections.Generic.IList<'T>
 
-let [<Import("*","test")>] babylon: BABYLON.IExports = jsNative
+let [<Import("*","Stage.PrivateCtor")>] babylon: BABYLON.IExports = jsNative
 
 module BABYLON =
 

--- a/test/fragments/breezejs/globalVariable.fs
+++ b/test/fragments/breezejs/globalVariable.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Fable.Core.JS
 
-let [<Import("FilterQueryOp","test")>] FilterQueryOp: FilterQueryOp = jsNative
+let [<Import("FilterQueryOp","globalVariable")>] FilterQueryOp: FilterQueryOp = jsNative
 
 type [<AllowNullLiteral>] FilterQueryOp =
     inherit Core.IEnum

--- a/test/fragments/monaco/variableInModule.fs
+++ b/test/fragments/monaco/variableInModule.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Fable.Core.JS
 
-let [<Import("*","test")>] monaco: Monaco.IExports = jsNative
+let [<Import("*","variableInModule")>] monaco: Monaco.IExports = jsNative
 
 module Monaco =
 

--- a/test/fragments/react/f5.fs
+++ b/test/fragments/react/f5.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Fable.Core.JS
 
-let [<Import("*","test")>] react: React.IExports = jsNative
+let [<Import("*","f5")>] react: React.IExports = jsNative
 
 module React =
 

--- a/test/fragments/reactxp/duplicatedVariableExports.fs
+++ b/test/fragments/reactxp/duplicatedVariableExports.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Fable.Core.JS
 
-let [<Import("*","reactxp")>] reactXP: ReactXP.IExports = jsNative
+let [<Import("*","ReactXP")>] reactXP: ReactXP.IExports = jsNative
 
 module ReactXP =
 

--- a/test/fragments/reactxp/multiple/ReactXP.fs
+++ b/test/fragments/reactxp/multiple/ReactXP.fs
@@ -36,7 +36,7 @@ module __web_Accessibility =
         [<Emit "new $0($1...)">] abstract Create: unit -> Accessibility
 
 module __web_ReactXP =
-    let [<Import("*","test/web/ReactXP")>] reactXP: ReactXP.IExports = jsNative
+    let [<Import("*","ReactXP/web/ReactXP")>] reactXP: ReactXP.IExports = jsNative
 
     module ReactXP =
 

--- a/test/fragments/regressions/#275-private-members.expected.fs
+++ b/test/fragments/regressions/#275-private-members.expected.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Fable.Core.JS
 
-let [<Import("PrivateMembersTests","test")>] privateMembersTests: PrivateMembersTests.IExports = jsNative
+let [<Import("PrivateMembersTests","#275-private-members")>] privateMembersTests: PrivateMembersTests.IExports = jsNative
 
 module PrivateMembersTests =
 

--- a/test/fragments/regressions/#277-unwrap-options.expected.fs
+++ b/test/fragments/regressions/#277-unwrap-options.expected.fs
@@ -4,8 +4,8 @@ open System
 open Fable.Core
 open Fable.Core.JS
 
-let [<Import("UnwrapOptions","test")>] unwrapOptions: UnwrapOptions.IExports = jsNative
-let [<Import("UnwrapOptionsAlias","test")>] unwrapOptionsAlias: UnwrapOptionsAlias.IExports = jsNative
+let [<Import("UnwrapOptions","#277-unwrap-options")>] unwrapOptions: UnwrapOptions.IExports = jsNative
+let [<Import("UnwrapOptionsAlias","#277-unwrap-options")>] unwrapOptionsAlias: UnwrapOptionsAlias.IExports = jsNative
 
 module UnwrapOptions =
 

--- a/test/fragments/regressions/#278-typeliterals-return.expected.fs
+++ b/test/fragments/regressions/#278-typeliterals-return.expected.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Fable.Core.JS
 
-let [<Import("TypeLiteralsAsReturnValue","test")>] typeLiteralsAsReturnValue: TypeLiteralsAsReturnValue.IExports = jsNative
+let [<Import("TypeLiteralsAsReturnValue","#278-typeliterals-return")>] typeLiteralsAsReturnValue: TypeLiteralsAsReturnValue.IExports = jsNative
 
 module TypeLiteralsAsReturnValue =
 

--- a/test/fragments/regressions/#288-type-alias-float-number.expected.fs
+++ b/test/fragments/regressions/#288-type-alias-float-number.expected.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Fable.Core.JS
 
-let [<Import("TypeAloasFloatNumber","test")>] typeAloasFloatNumber: TypeAloasFloatNumber.IExports = jsNative
+let [<Import("TypeAloasFloatNumber","#288-type-alias-float-number")>] typeAloasFloatNumber: TypeAloasFloatNumber.IExports = jsNative
 
 module TypeAloasFloatNumber =
 

--- a/test/fragments/regressions/#289-recursive-merge-modules.expected.fs
+++ b/test/fragments/regressions/#289-recursive-merge-modules.expected.fs
@@ -6,7 +6,7 @@ open Fable.Core.JS
 
 
 module Outer =
-    let [<Import("Inner","test/Outer")>] inner: Inner.IExports = jsNative
+    let [<Import("Inner","#289-recursive-merge-modules/Outer")>] inner: Inner.IExports = jsNative
 
     module Inner =
 

--- a/test/fragments/regressions/#292-static-props.expected.fs
+++ b/test/fragments/regressions/#292-static-props.expected.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Fable.Core.JS
 
-let [<Import("StaticTests","test")>] staticTests: StaticTests.IExports = jsNative
+let [<Import("StaticTests","#292-static-props")>] staticTests: StaticTests.IExports = jsNative
 
 module StaticTests =
 

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -157,7 +157,7 @@ describe "transform tests" <| fun _ ->
                         match FsType.asVariable tp with 
                         | Some vb -> 
                             match vb.Export with 
-                            | Some ex -> ex.Path = "test/web/ReactXP"
+                            | Some ex -> ex.Path = "ReactXP/web/ReactXP"
                             | None -> false
                         | None -> false
                     ) 

--- a/test/functionTests.fs
+++ b/test/functionTests.fs
@@ -120,7 +120,7 @@ describe "getJsModuleName tests" <| fun _ ->
         
     it "reactxp relative path" <| fun _ ->
         getJsModuleName "node_modules/reactxp/dist/web/ReactXP.d.ts"
-        |> equal "reactxp"            
+        |> equal "ReactXP" //todo: file name (`ReactXP`) or dir name (`reactxp`)
 
     it "node relative path" <| fun _ ->
         getJsModuleName "node_modules/@types/node/index.d.ts"

--- a/test/functionTests.fs
+++ b/test/functionTests.fs
@@ -134,6 +134,40 @@ describe "getJsModuleName tests" <| fun _ ->
         getJsModuleName "node_modules/izitoast/dist/izitoast/izitoast.d.ts"
         |> equal "izitoast"
 
+    it "just file name" <| fun _ ->
+        getJsModuleName "izitoast.d.ts"
+        |> equal "izitoast"
+
+    it "izitoast in parent dir" <| fun _ ->
+        getJsModuleName "../izitoast.d.ts"
+        |> equal "izitoast"
+
+    it "izitoast in current dir" <| fun _ ->
+        getJsModuleName "./izitoast.d.ts"
+        |> equal "izitoast"
+
+    let currentDirName = Node.Api.path.basename(Node.Api.``process``.cwd())
+
+    it "just index.d.ts" <| fun _ ->
+        getJsModuleName "index.d.ts"
+        |> equal currentDirName
+
+    it "index.d.ts in current dir" <| fun _ ->
+        getJsModuleName "./index.d.ts"
+        |> equal currentDirName
+
+    it "index.d.ts in current dir via parent dir" <| fun _ ->
+        getJsModuleName (sprintf "../%s/index.d.ts" currentDirName)
+        |> equal currentDirName
+    
+    it "scoped package" <| fun _ ->
+        getJsModuleName "node_modules/@slack/client"
+        |> equal "@slack/client"
+
+    it "scoped package in @types" <| fun _ ->
+        getJsModuleName "node_modules/@types/slack__client"
+        |> equal "@slack/client"
+
 
 describe "fixModuleName tests" <| fun _ ->
 


### PR DESCRIPTION
fixes #229

Currently `ts2fable` requires an input path with `node_modules`.   
Especially using `index.d.ts` in cwd doesn't work (`ts2fable index.d.ts out.fs`) and results in `Error: List was empty` (see #229).  
Other paths without `node_modules` produce unexpected module names (in `[<Import("[...]","XXX")>]`). For example: `ts2fable "E:\prog\fsharp\vscode.d.ts" out.fs` -> `[<Import("*","E:")>]`. Instead of file name (or last dir name in case of index.d.ts) ts2fable takes the first part as module name. Similar with `ts2fable ../index.d.ts out.fs` -> `[<Import("*","..")>]`

Currently ts2fable extracts the module name from the passed .d.ts path. This PR resolves the path to an absolute one. This should make module name generation more robust and handle relative paths and paths without `node_modules` better.

<br/>
<br/>

But: There's one change that might produce an incorrect result:
`node_modules/reactxp/dist/web/ReactXP.d.ts`  ([test case](https://github.com/fable-compiler/ts2fable/blob/3e02cb3d1a32060e123800af9c27c4108d7f6383/test/functionTests.fs#L122))  
Previously the extracted module name was `reactxp` (first dir after `node_modules`), now its `ReactXP` (file name). I'm not sure which one is correct.  
Outside of `node_modules` using file name (or directory name when `index.d.ts`) is probably the best guess and used as module name. But previously ts2fable always took the left most folder name -- which produced  strange results when the path doesn't contain `node_modules`. But inside `node_module`, I'm not sure which is correct. However in practice: I don't think it a) happens too often, and most of the time both names will probably be the same (`reactxp` <-> `ReactXP` -- it's used in javascript, so case shouldn't matter?). 
If there's a difference I'll add a special case for `node_modules`.

(You can see this change in action for all tests, too: Previously their import used `test` (`[<Import("...","test")>]`), now they emit their file name instead (`[<Import("*","variableInModule")>]`).)