### PR TITLE
Add generic type parameter constraints

### DIFF
--- a/src/bridge.fs
+++ b/src/bridge.fs
@@ -124,6 +124,7 @@ module internal Bridge =
         |> mergeModulesInFile
         |> aliasToInterfacePartly
         |> extractGenericParameterDefaults
+        |> removeInvalidGenericConstraints
         |> fixTypesHasESKeywords
         |> extractTypesInGlobalModules
         |> addConstructors

--- a/src/print.fs
+++ b/src/print.fs
@@ -17,13 +17,7 @@ let printType (tp: FsType): string =
             sprintf ">%s" (if un.Option then " option" else "") |> line.Add
             line |> String.concat ""
     | FsType.Generic g ->
-        let line = ResizeArray()
-        sprintf "%s" (printType g.Type) |> line.Add
-        if g.TypeParameters.Length > 0 then
-            "<" |> line.Add
-            g.TypeParameters |> List.map printType |> String.concat ", " |> line.Add
-            ">" |> line.Add
-        line |> String.concat ""
+        printGeneric g
     | FsType.Function ft ->
         let line = ResizeArray()
         let typs =
@@ -68,6 +62,15 @@ let printType (tp: FsType): string =
         printfn "unsupported printType %s: %s" (getTypeName tp) (getName tp)
         "obj"
 
+let printGeneric (g: FsGenericType): string =
+    let line = ResizeArray()
+    sprintf "%s" (printType g.Type) |> line.Add
+    if g.TypeParameters.Length > 0 then
+        "<" |> line.Add
+        g.TypeParameters |> List.map printType |> String.concat ", " |> line.Add
+        ">" |> line.Add
+    line |> String.concat ""
+
 let printEnumType (en: FsEnum): string =
     match en.Type with
     | FsEnumCaseType.Numeric -> "float"
@@ -87,6 +90,8 @@ let printFunction (fn: FsFunction): string =
         sprintf  "[<Emit \"%s\">] " emit |> line.Add
 
     sprintf "abstract %s" fn.Name.Value |> line.Add
+
+    // parameters
     let prms =
         fn.Params |> List.map(fun p ->
             if p.ParamArray then
@@ -106,6 +111,11 @@ let printFunction (fn: FsFunction): string =
     else
         sprintf ": %s" (prms |> String.concat " * ") |> line.Add
     sprintf " -> %s" (printType fn.ReturnType) |> line.Add
+
+    // generic type parameter constraints
+    printGenericTypeConstraints fn.TypeParameters
+    |> line.Add
+
     line |> String.concat ""
 
 let printProperty (pr: FsProperty): string =
@@ -123,12 +133,55 @@ let printProperty (pr: FsProperty): string =
         (if pr.Option then " option" else "")
         (if pr.IsReadonly then "" else " with get, set")
 
+let printGenericTypeConstraint (p: FsGenericTypeParameter): string option =
+    match p.Constraint with
+    | None -> None
+    | Some c ->
+        let formatConstraint = sprintf "%s :> %s" p.Name >> Some
+        let rec printConstraint =
+            function
+              // actual type or generic parameter name: `MyType`, `T`
+            | FsType.Mapped mp ->
+                formatConstraint mp.Name
+              // generic type: `MyType<...>
+            | FsType.Generic g ->
+                printGeneric g
+                |> formatConstraint
+              // and: `MyType1 & MyType2` (ts), `'T :> MyType1 and 'T :> MyType2` (F#)
+            | FsType.Tuple tp when tp.Kind = FsTupleKind.Intersection ->
+                tp.Types
+                |> List.choose printConstraint
+                |> function
+                   | [] -> None
+                   | cs ->
+                        cs
+                        |> String.concat " and "
+                        |> Some
+            | _ -> None
+        printConstraint c
+let printGenericTypeConstraints (tps: FsType list): string =
+    tps
+    |> List.choose FsType.asGenericTypeParameter
+    |> List.choose printGenericTypeConstraint
+    |> function
+       | [] -> ""
+       | cs ->
+           sprintf " when %s" (cs |> String.concat " and ")
+
+
 let printTypeParameters (tps: FsType list): string =
     if tps.Length = 0 then ""
     else
         let line = ResizeArray()
         line.Add "<"
+
+        // first: handle type parameter names
         tps |> List.map printType |> String.concat ", " |> line.Add
+
+        // then: handle constraints
+        printGenericTypeConstraints tps
+        |> line.Add
+
         line.Add ">"
         line |> String.concat ""
 

--- a/src/print.fs
+++ b/src/print.fs
@@ -47,6 +47,8 @@ let printType (tp: FsType): string =
     | FsType.Enum en ->
         printfn "unextracted printType %s: %s" (getTypeName tp) (getName tp)
         printEnumType en
+    | FsType.GenericTypeParameter gtp ->
+        gtp.Name
 
     // | FsType.Alias _ -> "obj"
     // | FsType.ExportAssignment _ -> "obj"

--- a/src/read.fs
+++ b/src/read.fs
@@ -79,20 +79,12 @@ let readTypeParameters (checker: TypeChecker) (tps: List<TypeParameterDeclaratio
     | None -> []
     | Some tps ->
         tps |> List.ofSeq |> List.map (fun tp ->
-            match tp.``default`` with
-            | Some df ->
-                {
-                    Default = readTypeNode checker df
-                    Name = tp.name.getText()
-                    FullName = getFullNodeName checker tp
-                }
-                |> FsType.GenericParameterDefaults
-            | None ->
-                {
-                    Name = tp.name.getText()
-                    FullName = getFullNodeName checker tp
-                }
-                |> FsType.Mapped
+            {
+                Name = tp.name.getText()
+                Constraint = tp.``constraint`` |> Option.map (readTypeNode checker)
+                Default = tp.``default`` |> Option.map (readTypeNode checker)
+            }
+            |> FsType.GenericTypeParameter
         )
 
 let readInherits (checker: TypeChecker) (hcs: List<HeritageClause> option): FsType list =

--- a/src/syntax.fs
+++ b/src/syntax.fs
@@ -35,11 +35,11 @@ type FsTypeLiteral =
         Members: FsType list
     }
 
-type FsGenericParameterDefaults =
+type FsGenericTypeParameter =
     {
-        Default: FsType
         Name: string
-        FullName: string
+        Constraint: FsType option
+        Default: FsType option
     }
 
 [<RequireQualifiedAccess>]
@@ -275,7 +275,7 @@ type FsType =
     | This
     | Import of FsImport
     | TypeLiteral of FsTypeLiteral
-    | GenericParameterDefaults of FsGenericParameterDefaults
+    | GenericTypeParameter of FsGenericTypeParameter
 
 [<RequireQualifiedAccess>]
 module FsType =
@@ -297,7 +297,7 @@ module FsType =
     let asModule (tp: FsType) = match tp with | FsType.Module v -> Some v | _ -> None
     let asVariable (tp: FsType) = match tp with | FsType.Variable v -> Some v | _ -> None
     let asExportAssignment (tp: FsType) = match tp with | FsType.ExportAssignment v -> Some v | _ -> None
-    let asGenericParameterDefaults (tp: FsType) = match tp with | FsType.GenericParameterDefaults v -> Some v | _ -> None
+    let asGenericTypeParameter (tp: FsType) = match tp with | FsType.GenericTypeParameter v -> Some v | _ -> None
 
 type FsModule =
     {
@@ -393,7 +393,7 @@ let getTypeName (tp: FsType) =
     | FsType.Import t -> t.GetType().ToString()
     | FsType.Array t -> t.GetType().ToString()
     | FsType.ExportAssignment t -> t.GetType().ToString()
-    | FsType.GenericParameterDefaults t -> t.GetType().ToString()
+    | FsType.GenericTypeParameter t -> t.GetType().ToString()
     | FsType.None as t -> t.GetType().ToString() + ".None"
     | FsType.TODO as t -> t.GetType().ToString() + ".TODO"
     | FsType.StringLiteral t -> t.GetType().ToString()
@@ -419,7 +419,7 @@ let getAccessibility (tp: FsType) : FsAccessibility option =
     | FsType.Import _
     | FsType.Array _
     | FsType.ExportAssignment _
-    | FsType.GenericParameterDefaults _
+    | FsType.GenericTypeParameter _
     | FsType.None
     | FsType.TODO
     | FsType.StringLiteral _

--- a/src/transform.fs
+++ b/src/transform.fs
@@ -139,6 +139,7 @@ let rec fixTypeEx (ns: string) (doFix:FsType->bool) (fix: string->FsType->FsType
     | FsType.Import _ -> tp
     | FsType.GenericTypeParameter gtp ->
         { gtp with
+            Constraint = gtp.Constraint |> Option.map fixType
             Default = gtp.Default |> Option.map fixType
         }
         |> FsType.GenericTypeParameter

--- a/test-compile/test-compile.fsproj
+++ b/test-compile/test-compile.fsproj
@@ -10,7 +10,7 @@
     <!-- <Compile Include="VSCode.fs" /> -->
     <Compile Include="IziToast.fs" />
     <!-- <Compile Include="Electron.fs" /> -->
-    <Compile Include="React.fs" />
+    <!-- <Compile Include="React.fs" /> -->
     <!-- <Compile Include="ReactNative.fs" /> -->
     <Compile Include="Mocha.fs" />
     <!-- <Compile Include="Monaco.fs" /> -->

--- a/test/fragments/custom/generic-type-constraints/and.d.ts
+++ b/test/fragments/custom/generic-type-constraints/and.d.ts
@@ -1,0 +1,7 @@
+export interface A { readonly alpha: number }
+export interface B { readonly beta: string }
+export interface C<T> { readonly value: T }
+
+export interface And1<T extends A & B> {}
+export interface And2<T extends A & B & C<A> & C<B>> {}
+export interface And3<T extends A, U extends B & C<T>> {}

--- a/test/fragments/custom/generic-type-constraints/and.d.ts
+++ b/test/fragments/custom/generic-type-constraints/and.d.ts
@@ -5,3 +5,4 @@ export interface C<T> { readonly value: T }
 export interface And1<T extends A & B> {}
 export interface And2<T extends A & B & C<A> & C<B>> {}
 export interface And3<T extends A, U extends B & C<T>> {}
+export interface And4<T extends C<A & B>> {}

--- a/test/fragments/custom/generic-type-constraints/and.expected.fs
+++ b/test/fragments/custom/generic-type-constraints/and.expected.fs
@@ -22,3 +22,6 @@ type [<AllowNullLiteral>] And2<'T when 'T :> A and 'T :> B and 'T :> C<A> and 'T
 
 type [<AllowNullLiteral>] And3<'T, 'U when 'T :> A and 'U :> B and 'U :> C<'T>> =
     interface end
+
+type [<AllowNullLiteral>] And4<'T when 'T :> C<obj>> =
+    interface end

--- a/test/fragments/custom/generic-type-constraints/and.expected.fs
+++ b/test/fragments/custom/generic-type-constraints/and.expected.fs
@@ -1,0 +1,24 @@
+// ts2fable 0.8.0
+module rec and
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+type [<AllowNullLiteral>] A =
+    abstract alpha: float
+
+type [<AllowNullLiteral>] B =
+    abstract beta: string
+
+type [<AllowNullLiteral>] C<'T> =
+    abstract value: 'T
+
+type [<AllowNullLiteral>] And1<'T when 'T :> A and 'T :> B> =
+    interface end
+
+type [<AllowNullLiteral>] And2<'T when 'T :> A and 'T :> B and 'T :> C<A> and 'T :> C<B>> =
+    interface end
+
+type [<AllowNullLiteral>] And3<'T, 'U when 'T :> A and 'U :> B and 'U :> C<'T>> =
+    interface end

--- a/test/fragments/custom/generic-type-constraints/combination.d.ts
+++ b/test/fragments/custom/generic-type-constraints/combination.d.ts
@@ -1,0 +1,10 @@
+export interface A { readonly alpha: number }
+export interface B { readonly beta: string }
+export interface C<T> { readonly value: T }
+
+// `'T :> A`
+export interface Comb1<T extends A & (B | C<B>)> {}
+// ``
+export interface Comb2<T extends A | (B & C<B>)> {}
+// ``
+export interface Comb3<T extends (A | C<A>) & (B | C<B>)> {}

--- a/test/fragments/custom/generic-type-constraints/combination.expected.fs
+++ b/test/fragments/custom/generic-type-constraints/combination.expected.fs
@@ -1,0 +1,24 @@
+// ts2fable 0.8.0
+module rec combination
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+type [<AllowNullLiteral>] A =
+    abstract alpha: float
+
+type [<AllowNullLiteral>] B =
+    abstract beta: string
+
+type [<AllowNullLiteral>] C<'T> =
+    abstract value: 'T
+
+type [<AllowNullLiteral>] Comb1<'T when 'T :> A> =
+    interface end
+
+type [<AllowNullLiteral>] Comb2<'T> =
+    interface end
+
+type [<AllowNullLiteral>] Comb3<'T> =
+    interface end

--- a/test/fragments/custom/generic-type-constraints/default.d.ts
+++ b/test/fragments/custom/generic-type-constraints/default.d.ts
@@ -1,0 +1,16 @@
+export interface A { readonly alpha: number }
+export interface B { readonly beta: string }
+interface AB extends A, B {}
+export interface C<T> { readonly value: T }
+
+export interface D1<T extends A & B = AB> {}
+// doesn't work in F#: `= A & B` -> `obj`
+//  -> "The type 'obj' is not compatible with the type 'A'"
+// export interface D1no<T extends A & B = A & B> {}
+
+export interface D2<T extends C<A> = C<A>> {}
+// doesn't work in F#: `C<AB>`
+// -> The type 'A' does not match the type 'AB'
+// export interface D2no<T extends C<A> = C<AB>> {}
+
+export interface D3<T extends {} = {}> {}

--- a/test/fragments/custom/generic-type-constraints/default.expected.fs
+++ b/test/fragments/custom/generic-type-constraints/default.expected.fs
@@ -1,0 +1,37 @@
+// ts2fable 0.8.0
+module rec default
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+type [<AllowNullLiteral>] A =
+    abstract alpha: float
+
+type [<AllowNullLiteral>] B =
+    abstract beta: string
+
+type [<AllowNullLiteral>] AB =
+    inherit A
+    inherit B
+
+type [<AllowNullLiteral>] C<'T> =
+    abstract value: 'T
+
+type D1 =
+    D1<AB>
+
+type [<AllowNullLiteral>] D1<'T when 'T :> A and 'T :> B> =
+    interface end
+
+type D2 =
+    D2<C<A>>
+
+type [<AllowNullLiteral>] D2<'T when 'T :> C<A>> =
+    interface end
+
+type D3 =
+    D3<obj>
+
+type [<AllowNullLiteral>] D3<'T> =
+    interface end

--- a/test/fragments/custom/generic-type-constraints/etc.d.ts
+++ b/test/fragments/custom/generic-type-constraints/etc.d.ts
@@ -1,0 +1,12 @@
+
+// ``
+export interface O1<T extends {}> {}
+// ``
+export interface O2<T extends { new (): T }> {}
+// ``
+export interface O3<T, U extends { new (...args: any[]): T }> {}
+// ``
+export interface O4<T extends { value: true}> {}
+
+// ``
+export interface O5<T extends "foo"> {}

--- a/test/fragments/custom/generic-type-constraints/etc.expected.fs
+++ b/test/fragments/custom/generic-type-constraints/etc.expected.fs
@@ -1,0 +1,20 @@
+// ts2fable 0.8.0
+module rec etc
+open System
+open Fable.Core
+open Fable.Core.JS
+
+type [<AllowNullLiteral>] O1<'T> =
+    interface end
+
+type [<AllowNullLiteral>] O2<'T> =
+    interface end
+
+type [<AllowNullLiteral>] O3<'T, 'U> =
+    interface end
+
+type [<AllowNullLiteral>] O4<'T> =
+    interface end
+
+type [<AllowNullLiteral>] O5<'T> =
+    interface end

--- a/test/fragments/custom/generic-type-constraints/function.d.ts
+++ b/test/fragments/custom/generic-type-constraints/function.d.ts
@@ -1,0 +1,11 @@
+export interface A { readonly alpha: number }
+export interface B { readonly beta: string }
+export interface C<T> { readonly value: T }
+
+export function f1<T extends A>(): void
+export function f2<T extends A & B>(): void
+
+export interface I1 {
+  f1<T extends A>(value: T): void
+  f2<T extends A, U extends B>(value1: T, value2: U): void
+}

--- a/test/fragments/custom/generic-type-constraints/function.expected.fs
+++ b/test/fragments/custom/generic-type-constraints/function.expected.fs
@@ -1,0 +1,23 @@
+// ts2fable 0.8.0
+module rec function
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+type [<AllowNullLiteral>] IExports =
+    abstract f1: unit -> unit when 'T :> A
+    abstract f2: unit -> unit when 'T :> A and 'T :> B
+
+type [<AllowNullLiteral>] A =
+    abstract alpha: float
+
+type [<AllowNullLiteral>] B =
+    abstract beta: string
+
+type [<AllowNullLiteral>] C<'T> =
+    abstract value: 'T
+
+type [<AllowNullLiteral>] I1 =
+    abstract f1: value: 'T -> unit when 'T :> A
+    abstract f2: value1: 'T * value2: 'U -> unit when 'T :> A and 'U :> B

--- a/test/fragments/custom/generic-type-constraints/invalid_fsharp.d.ts
+++ b/test/fragments/custom/generic-type-constraints/invalid_fsharp.d.ts
@@ -1,0 +1,36 @@
+// all examples here are valid TypeScript
+// and can be converted by ts2fable
+// but produce invalid F#
+
+export module UnusedTypeParameter {
+  interface A { }
+
+  type T1<T extends A> = {}
+  type T2<T> = T1<T>
+  //           ^^^^^
+  //           A type parameter is missing a constraint 'when 'T :> A'
+
+  // Note: Only valid in TS because `A` is empty
+  //       `interface A { alpha: number }`
+  //       -> TS compiler complains about missing constraint
+}
+
+export module ExtendOtherTypeParameter {
+  interface A { alpha: number }
+  
+  interface T1<T extends A, U extends T> {}
+  //                        ^
+  //                        This type parameter has been used in a way that constrains it to always be '#A'
+}
+
+export module StructuralSubtyping {
+  // `A` and `B` have same shape -> are equal
+  // But are different in F#
+  interface A {}
+  interface B {}
+
+  interface T1<T extends A> {}
+  interface T2<T extends T1<B>> {}
+  //                     ^^^^^^
+  //                     The type 'B' is not compatible with the type 'A'
+}

--- a/test/fragments/custom/generic-type-constraints/invalid_fsharp.d.ts
+++ b/test/fragments/custom/generic-type-constraints/invalid_fsharp.d.ts
@@ -105,3 +105,16 @@ export module TypeAndExtendedTypeForSameParameter {
     // The type 'Aext' does not match the type 'A'
   }
 }
+
+export module TypeParamterDefault {
+  interface C<T> { value: T }
+
+  interface T1<T extends C<any> = C<string>> {} 
+  // generates 
+  // ```fsharp
+  // type [<AllowNullLiteral>] T1<'T when 'T :> C<obj option>> = interface end
+  // type T1 = T1<C<string>>
+  //           ^^^^^^^^^^^^^
+  //           The type 'obj option' does not match the type 'string'
+  // ```
+}

--- a/test/fragments/custom/generic-type-constraints/invalid_fsharp.d.ts
+++ b/test/fragments/custom/generic-type-constraints/invalid_fsharp.d.ts
@@ -26,11 +26,82 @@ export module ExtendOtherTypeParameter {
 export module StructuralSubtyping {
   // `A` and `B` have same shape -> are equal
   // But are different in F#
+
   interface A {}
   interface B {}
 
   interface T1<T extends A> {}
   interface T2<T extends T1<B>> {}
-  //                     ^^^^^^
+  //                     ^^^^^
   //                     The type 'B' is not compatible with the type 'A'
+}
+
+export module StructuralSubtypingWithOptionalField {
+  // Special case of the example above:
+  // `A` and `B` are different, but can have the same shape:
+  // All fields in `A` are optional -> no fields specified -> `A` is `{}`
+
+  interface A {
+    value?: number
+  }
+  interface B {}
+
+  interface T1<T extends A> {}
+  interface T2<T extends T1<B>> {}
+  //                     ^^^^^
+  //                     The type 'B' is not compatible with the type 'A'
+}
+
+export module MakeGenericMoreSpecific {
+  interface A { alpha: number }
+  interface B { beta: string }
+  interface C<T> { value: T }
+
+  interface T1<T extends C<any>> {}
+  interface S1<T extends T1<C<T>>> {}
+  //                     ^^^^^^^^
+  //                     The type 'obj option' does not match the type ''T'
+
+  interface T2<T extends C<A | B>> {}
+  interface S2<T extends T2<C<A>>> {}
+  //                     ^^^^^^^^
+  //                     The type 'U2<A,B>' does not match the type 'A'
+}
+
+export module ReduceToInvalidGenericItem {
+  // Type might be valid inside a generic, but invalid when extracted
+  // like sealed types (`Function`->`Action`) or Tuples (`A | B`):
+  // both are ok inside a generic:
+  //   * `T extends C<Function>` -> `'T when 'T :> C<Function>`
+  //   * `T extends C<A|B>` -> `T when 'T :> C<U2<A,B>>`
+  // but are removed as direct constraints: 
+  //   * `T extends Function` -> `'T`
+  //   * `T extends A | B` -> `'T`
+
+  interface A { alpha: number }
+  interface B { beta: string }
+  interface C<T> { value: T }
+
+  interface T1<T extends C<Function>> {}
+  type S1<T extends Function> = T1<C<T>>
+  //                            ^^^^^^^^
+  //                            The type 'Function' does not match the type ''T'
+
+  interface T2<T extends C<A | B>> {}
+  type S2<T extends A | B> = T2<C<T>>
+  //                         ^^^^^^^^
+  //                         The type 'U2<A,B>' does not match the type ''T'
+}
+
+export module TypeAndExtendedTypeForSameParameter {
+  interface A { alpha: number }
+  interface Aext extends A {}
+  interface C<T> { value: T }
+  
+  interface T1<T extends A, K extends C<T>> {}
+  interface S1 {
+    v: T1<Aext, C<A>>
+    // ^^^^^^^^^^^^^^
+    // The type 'Aext' does not match the type 'A'
+  }
 }

--- a/test/fragments/custom/generic-type-constraints/or.d.ts
+++ b/test/fragments/custom/generic-type-constraints/or.d.ts
@@ -1,0 +1,10 @@
+export interface A { readonly alpha: number }
+export interface B { readonly beta: string }
+export interface C<T> { readonly value: T }
+
+// ignore -> just `Or1<'T>`
+export interface Or1<T extends A | B> {}
+
+// `A | B` is allowed inside generic
+// -> `C<U2<A,B>>`
+export interface Or2<T extends C<A | B>> {}

--- a/test/fragments/custom/generic-type-constraints/or.expected.fs
+++ b/test/fragments/custom/generic-type-constraints/or.expected.fs
@@ -1,0 +1,21 @@
+// ts2fable 0.8.0
+module rec or
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+type [<AllowNullLiteral>] A =
+    abstract alpha: float
+
+type [<AllowNullLiteral>] B =
+    abstract beta: string
+
+type [<AllowNullLiteral>] C<'T> =
+    abstract value: 'T
+
+type [<AllowNullLiteral>] Or1<'T> =
+    interface end
+
+type [<AllowNullLiteral>] Or2<'T when 'T :> C<U2<A, B>>> =
+    interface end

--- a/test/fragments/custom/generic-type-constraints/sealed.d.ts
+++ b/test/fragments/custom/generic-type-constraints/sealed.d.ts
@@ -1,0 +1,22 @@
+export interface A { readonly alpha: number }
+export interface B { readonly beta: string }
+export interface C<T> { readonly value: T }
+
+// remove sealed types from constraints
+export interface Sealed1<T extends Function> {}
+export interface Sealed2<T extends ReadonlySet<A>> {}
+export interface Sealed3<T extends ReadonlyMap<A, B>> {}
+
+// allowed inside generics
+export interface Sealed4<T extends C<Function>> {}
+
+// remove when used in `&`
+// ``
+export interface Sealed5<T extends Function & ReadonlySet<A>> {}
+// `'T :> A`
+export interface Sealed6<T extends Function & A> {}
+// `'T :> A`
+export interface Sealed7<T extends A & Function> {}
+// `'T :> A and 'T :> B`
+export interface Sealed8<T extends A & Function & B> {}
+

--- a/test/fragments/custom/generic-type-constraints/sealed.expected.fs
+++ b/test/fragments/custom/generic-type-constraints/sealed.expected.fs
@@ -1,0 +1,41 @@
+// ts2fable 0.8.0
+module rec sealed
+open System
+open Fable.Core
+open Fable.Core.JS
+
+type Function = System.Action
+
+
+type [<AllowNullLiteral>] A =
+    abstract alpha: float
+
+type [<AllowNullLiteral>] B =
+    abstract beta: string
+
+type [<AllowNullLiteral>] C<'T> =
+    abstract value: 'T
+
+type [<AllowNullLiteral>] Sealed1<'T> =
+    interface end
+
+type [<AllowNullLiteral>] Sealed2<'T> =
+    interface end
+
+type [<AllowNullLiteral>] Sealed3<'T> =
+    interface end
+
+type [<AllowNullLiteral>] Sealed4<'T when 'T :> C<Function>> =
+    interface end
+
+type [<AllowNullLiteral>] Sealed5<'T> =
+    interface end
+
+type [<AllowNullLiteral>] Sealed6<'T when 'T :> A> =
+    interface end
+
+type [<AllowNullLiteral>] Sealed7<'T when 'T :> A> =
+    interface end
+
+type [<AllowNullLiteral>] Sealed8<'T when 'T :> A and 'T :> B> =
+    interface end

--- a/test/fragments/custom/generic-type-constraints/simple.d.ts
+++ b/test/fragments/custom/generic-type-constraints/simple.d.ts
@@ -1,0 +1,17 @@
+// interface WITH fields:
+//   type checking is based on shape of interface or type ("duck typing" or "structural subtyping")
+//   -> `interface A {}` and `interface B {}` are equal
+//   that would allow things like:
+//   ```
+//   interface T1<T extends A> {}
+//   interface T2<T extends T1<B>> {}
+//   ```
+//   -> correct in typescript, but not in F#
+export interface A { readonly alpha: number }
+export interface B { readonly beta: string }
+export interface C<T> { readonly value: T }
+
+export interface Simple1<T extends A> {}
+export interface Simple2<T extends C<A>> {}
+export interface Simple3<T extends A, U extends B> {}
+export interface Simple4<T extends A, U extends C<T>> {}

--- a/test/fragments/custom/generic-type-constraints/simple.expected.fs
+++ b/test/fragments/custom/generic-type-constraints/simple.expected.fs
@@ -1,0 +1,27 @@
+// ts2fable 0.8.0
+module rec simple
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+type [<AllowNullLiteral>] A =
+    abstract alpha: float
+
+type [<AllowNullLiteral>] B =
+    abstract beta: string
+
+type [<AllowNullLiteral>] C<'T> =
+    abstract value: 'T
+
+type [<AllowNullLiteral>] Simple1<'T when 'T :> A> =
+    interface end
+
+type [<AllowNullLiteral>] Simple2<'T when 'T :> C<A>> =
+    interface end
+
+type [<AllowNullLiteral>] Simple3<'T, 'U when 'T :> A and 'U :> B> =
+    interface end
+
+type [<AllowNullLiteral>] Simple4<'T, 'U when 'T :> A and 'U :> C<'T>> =
+    interface end

--- a/test/fragments/custom/generic-type-constraints/types.d.ts
+++ b/test/fragments/custom/generic-type-constraints/types.d.ts
@@ -1,0 +1,7 @@
+export interface A { readonly alpha: number }
+export interface B { readonly beta: string }
+export interface C<T> { readonly value: T }
+
+export interface T1<T extends A> {}
+export type T2<T extends A> = {}
+export class T3<T extends A> {}

--- a/test/fragments/custom/generic-type-constraints/types.expected.fs
+++ b/test/fragments/custom/generic-type-constraints/types.expected.fs
@@ -1,0 +1,30 @@
+// ts2fable 0.8.0
+module rec types
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+type [<AllowNullLiteral>] IExports =
+    abstract T3: T3Static
+
+type [<AllowNullLiteral>] A =
+    abstract alpha: float
+
+type [<AllowNullLiteral>] B =
+    abstract beta: string
+
+type [<AllowNullLiteral>] C<'T> =
+    abstract value: 'T
+
+type [<AllowNullLiteral>] T1<'T when 'T :> A> =
+    interface end
+
+type [<AllowNullLiteral>] T2<'T when 'T :> A> =
+    interface end
+
+type [<AllowNullLiteral>] T3<'T when 'T :> A> =
+    interface end
+
+type [<AllowNullLiteral>] T3Static =
+    [<Emit "new $0($1...)">] abstract Create: unit -> T3<'T> when 'T :> A

--- a/test/fragments/react/f2.fs
+++ b/test/fragments/react/f2.fs
@@ -3,6 +3,7 @@ module rec f2
 open System
 open Fable.Core
 open Fable.Core.JS
+open Browser.Types
 
 type ClassAttributes = React.ClassAttributes
 type ReactNode = React.ReactNode
@@ -11,9 +12,9 @@ type HTMLAttributes = React.HTMLAttributes
 type DOMAttributes = React.DOMAttributes
 type DetailedReactHTMLElement = React.DetailedReactHTMLElement
 
-type [<AllowNullLiteral>] DOMFactory<'P, 'T> =
+type [<AllowNullLiteral>] DOMFactory<'P, 'T when 'P :> DOMAttributes<'T> and 'T :> Element> =
     [<Emit "$0($1...)">] abstract Invoke: ?props: obj * [<ParamArray>] children: ResizeArray<ReactNode> -> DOMElement<'P, 'T>
 
-type [<AllowNullLiteral>] DetailedHTMLFactory<'P, 'T> =
+type [<AllowNullLiteral>] DetailedHTMLFactory<'P, 'T when 'P :> HTMLAttributes<'T> and 'T :> HTMLElement> =
     inherit DOMFactory<'P, 'T>
     [<Emit "$0($1...)">] abstract Invoke: ?props: obj * [<ParamArray>] children: ResizeArray<ReactNode> -> DetailedReactHTMLElement<'P, 'T>

--- a/test/fragments/react/f4.fs
+++ b/test/fragments/react/f4.fs
@@ -13,7 +13,7 @@ module React =
         abstract Component: ComponentStatic
 
     type [<AllowNullLiteral>] Component<'P, 'S> =
-        abstract setState: state: U2<(obj -> 'P -> U2<obj, 'S>), U2<obj, 'S>> * ?callback: (unit -> obj option) -> unit
+        abstract setState: state: U2<(obj -> 'P -> U2<obj, 'S>), U2<obj, 'S>> * ?callback: (unit -> obj option) -> unit when 'K :> 'S
 
     type [<AllowNullLiteral>] ComponentStatic =
         [<Emit "new $0($1...)">] abstract Create: unit -> Component<'P, 'S>

--- a/test/fragments/react/f6.fs
+++ b/test/fragments/react/f6.fs
@@ -8,5 +8,5 @@ type Component = React.Component
 type ComponentState = React.ComponentState
 type ComponentClass = React.ComponentClass
 
-type [<AllowNullLiteral>] ClassType<'P, 'T, 'C> =
+type [<AllowNullLiteral>] ClassType<'P, 'T, 'C when 'T :> Component<'P, ComponentState> and 'C :> ComponentClass<'P>> =
     interface end

--- a/test/fragments/react/f7.fs
+++ b/test/fragments/react/f7.fs
@@ -6,5 +6,5 @@ open Fable.Core.JS
 
 type SyntheticEvent = React.SyntheticEvent
 
-type [<AllowNullLiteral>] EventHandler<'E> =
+type [<AllowNullLiteral>] EventHandler<'E when 'E :> SyntheticEvent<obj option>> =
     abstract bivarianceHack: ``event``: 'E -> unit

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -356,6 +356,42 @@ describe "transform tests" <| fun _ ->
         let fsPath = "test/fragments/babylonjs/Stage.PrivateCtor.fs"
         let expected = "test/fragments/babylonjs/Stage.PrivateCtor.expected.fs"
         convertAndCompareAgainstExpected tsPaths fsPath expected
+    
+    it "generic-type-constraints/simple" <| fun _ ->
+        let tsPaths = ["test/fragments/custom/generic-type-constraints/simple.d.ts"]
+        let fsPath = "test/fragments/custom/generic-type-constraints/simple.fs"
+        let expected = "test/fragments/custom/generic-type-constraints/simple.expected.fs"
+        convertAndCompareAgainstExpected tsPaths fsPath expected
+    it "generic-type-constraints/and" <| fun _ ->
+        let tsPaths = ["test/fragments/custom/generic-type-constraints/and.d.ts"]
+        let fsPath = "test/fragments/custom/generic-type-constraints/and.fs"
+        let expected = "test/fragments/custom/generic-type-constraints/and.expected.fs"
+        convertAndCompareAgainstExpected tsPaths fsPath expected
+    it "generic-type-constraints/or" <| fun _ ->
+        let tsPaths = ["test/fragments/custom/generic-type-constraints/or.d.ts"]
+        let fsPath = "test/fragments/custom/generic-type-constraints/or.fs"
+        let expected = "test/fragments/custom/generic-type-constraints/or.expected.fs"
+        convertAndCompareAgainstExpected tsPaths fsPath expected
+    it "generic-type-constraints/combination" <| fun _ ->
+        let tsPaths = ["test/fragments/custom/generic-type-constraints/combination.d.ts"]
+        let fsPath = "test/fragments/custom/generic-type-constraints/combination.fs"
+        let expected = "test/fragments/custom/generic-type-constraints/combination.expected.fs"
+        convertAndCompareAgainstExpected tsPaths fsPath expected
+    it "generic-type-constraints/sealed" <| fun _ ->
+        let tsPaths = ["test/fragments/custom/generic-type-constraints/sealed.d.ts"]
+        let fsPath = "test/fragments/custom/generic-type-constraints/sealed.fs"
+        let expected = "test/fragments/custom/generic-type-constraints/sealed.expected.fs"
+        convertAndCompareAgainstExpected tsPaths fsPath expected
+    it "generic-type-constraints/types" <| fun _ ->
+        let tsPaths = ["test/fragments/custom/generic-type-constraints/types.d.ts"]
+        let fsPath = "test/fragments/custom/generic-type-constraints/types.fs"
+        let expected = "test/fragments/custom/generic-type-constraints/types.expected.fs"
+        convertAndCompareAgainstExpected tsPaths fsPath expected
+    it "generic-type-constraints/function" <| fun _ ->
+        let tsPaths = ["test/fragments/custom/generic-type-constraints/function.d.ts"]
+        let fsPath = "test/fragments/custom/generic-type-constraints/function.fs"
+        let expected = "test/fragments/custom/generic-type-constraints/function.expected.fs"
+        convertAndCompareAgainstExpected tsPaths fsPath expected
 
     // https://github.com/fable-compiler/ts2fable/pull/275
     it "regression #275 remove private members" <| fun _ ->

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -397,6 +397,11 @@ describe "transform tests" <| fun _ ->
         let fsPath = "test/fragments/custom/generic-type-constraints/etc.fs"
         let expected = "test/fragments/custom/generic-type-constraints/etc.expected.fs"
         convertAndCompareAgainstExpected tsPaths fsPath expected
+    it "generic-type-constraints/default" <| fun _ ->
+        let tsPaths = ["test/fragments/custom/generic-type-constraints/default.d.ts"]
+        let fsPath = "test/fragments/custom/generic-type-constraints/default.fs"
+        let expected = "test/fragments/custom/generic-type-constraints/default.expected.fs"
+        convertAndCompareAgainstExpected tsPaths fsPath expected
 
     // https://github.com/fable-compiler/ts2fable/pull/275
     it "regression #275 remove private members" <| fun _ ->

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -392,6 +392,11 @@ describe "transform tests" <| fun _ ->
         let fsPath = "test/fragments/custom/generic-type-constraints/function.fs"
         let expected = "test/fragments/custom/generic-type-constraints/function.expected.fs"
         convertAndCompareAgainstExpected tsPaths fsPath expected
+    it "generic-type-constraints/etc" <| fun _ ->
+        let tsPaths = ["test/fragments/custom/generic-type-constraints/etc.d.ts"]
+        let fsPath = "test/fragments/custom/generic-type-constraints/etc.fs"
+        let expected = "test/fragments/custom/generic-type-constraints/etc.expected.fs"
+        convertAndCompareAgainstExpected tsPaths fsPath expected
 
     // https://github.com/fable-compiler/ts2fable/pull/275
     it "regression #275 remove private members" <| fun _ ->


### PR DESCRIPTION
Fixes #84


Adds handling of generic type parameter constraints.
Beside simple constraints (like `T extends A` -> `'T when 'T :> A`), intersections are handled: `T extends A & B` -> `'T when 'T :> A and 'T :> B`. Unions aren't supported (`'T extends A | B`)

Special behaviour:
* Unsupported constraints are ignored: `type MyType<'T extends A | B> = ...` -> `type MyType<'T> = ...`
* Types that are sealed in F# are ignored (like `Function` -> `System.Action`)
* Unsupported parts in intersections are ignored, while all others are handled: `'T extends A & Function & B & (C | D)` -> `'T when 'T :> A and 'T :> B`

<br/>
<br/>

Constraints in Typescript are quite versatile. Quite often they cannot be translated directly into F# (without a lot of effort...). And unfortunately not all such cases can be caught (again: without a lot of effort...).  

See `test\fragments\custom\generic-type-constraints\invalid_fsharp.d.ts` for some examples.  

In practice, most cases are either based on structural subtyping or making generics more specific.

For example: Interfaces in TypeScript are equal based on their shape, not their type:
```typescript
interface A {}
interface B {}
interface C<T extends A> {}
type D<T extend B> = C<T>
```
```fsharp
type A = interface end
type B = interface end

type C<'T when 'T :> A> = interface end

type D<'T when 'T :> B> = C<'T>
//                        ^^^^^
//                        A type parameter is missing a constraint 'when 'T :> A'
```
`A` and `B` have same shape and match in TypeScript. In F# they are different types.


Another example with generics:
```typescript
interface C<T> {}
interface T1<T extends C<any>> {}
interface T2<T extends T1<C<string>>> 
```
```fsharp
type C<'T> = interface end
type T1<'T when 'T :> C<obj option>> = interface end

type T2<'T when 'T :> T1<C<string>>> = interface end
//                    ^^^^^^^^^^^^^^
//                     The type 'obj option' does not match the type 'string'
```
`C<any>` in `T1` gets more specific in `T2` (to `C<string>`). But in F# `any` gets translated into `obj option` -- and isn't compatible with `string` any more.

Like mentioned above: I collected a couple of representative examples in `test\fragments\custom\generic-type-constraints\invalid_fsharp.d.ts`. These are all valid TypeScript, can be transformed by ts2fable, but produce errors in F#.

<br/>
<br/>

In practice that might be a huge issue: A newly translated file can produce quite a lot errors.  
`React` from `test-compile` test suite reports `16` errors (and a couple of "This construct causes code to be less generic than indicated by the type annotations.") (-> `React` is exclude from compile tests).  
These errors basically boil down to the two examples above, and are relatively easy to fix by hand. But they are still quite intimidating. And to fix them you still have to dig into the code and differences between TypeScript and F#. Probably not ideal for a tool that should make life more easy....

I still think constraints do more good than harm. But in some situations it might complicate things. Maybe an option to disable generic constraints might be reasonable?

<br/>
<br/>

Another idea to enhance handling of generic constraints (independent of switch to turn constraints on/off): Emit type parameter documentation containing the original TypeScript constraints:
```fsharp
/// <typeparam name="T">TS: <c>extends A & (B | C<B>)</c></typeparam>
type [<AllowNullLiteral>] T<'T when 'T :> A> =
    interface end
```
It's actually quite easy to implement, but currently not part of this PR.