### PR TITLE
Add comparison of xml comments for tests

### DIFF
--- a/test/fragments/regressions/#368-compare-xml-comments.fail.d.ts
+++ b/test/fragments/regressions/#368-compare-xml-comments.fail.d.ts
@@ -1,0 +1,4 @@
+/**
+ * XML comments are compared
+ */
+interface SomeInterface {}

--- a/test/fragments/regressions/#368-compare-xml-comments.fail.expected.fs
+++ b/test/fragments/regressions/#368-compare-xml-comments.fail.expected.fs
@@ -1,0 +1,11 @@
+// ts2fable 0.8.0
+module rec #368-compare-xml-comments.fail
+open System
+open Fable.Core
+open Fable.Core.JS
+
+// code comments are ignored
+
+/// XML comments are compared -- additional text to fail
+type [<AllowNullLiteral>] SomeInterface =
+    interface end

--- a/test/fragments/regressions/#368-compare-xml-comments.pass.d.ts
+++ b/test/fragments/regressions/#368-compare-xml-comments.pass.d.ts
@@ -1,0 +1,4 @@
+/**
+ * XML comments are compared
+ */
+interface SomeInterface {}

--- a/test/fragments/regressions/#368-compare-xml-comments.pass.expected.fs
+++ b/test/fragments/regressions/#368-compare-xml-comments.pass.expected.fs
@@ -1,0 +1,11 @@
+// ts2fable 0.8.0
+module rec #368-compare-xml-comments.pass
+open System
+open Fable.Core
+open Fable.Core.JS
+
+// code comments are ignored
+
+/// XML comments are compared
+type [<AllowNullLiteral>] SomeInterface =
+    interface end


### PR DESCRIPTION
Inspired by https://github.com/fable-compiler/ts2fable/pull/367#pullrequestreview-530824836

Currently xml comments (`///`) are ignored during testing -> Files with same code, but different xml comments still match.  
This changes that: XML comments must match too. Normal comments (`//`) are still ignored.