### PR TITLE
Fix #374: Invalid function name when parameter with string literal type contains space

### DIFF
--- a/src/transform.fs
+++ b/src/transform.fs
@@ -479,9 +479,18 @@ let fixOverloadingOnStringParameters(f: FsFile): FsFile =
                         "," |> kind.Add
                 )
                 ")" |> kind.Add
+                let name = 
+                    let name = String.concat "" name
+                    // replace whitespaces with `_`
+                    let name = name.Replace(' ', '_').Replace('\t', '_')
+                    // if still invalid identifier: put into double backticks
+                    if name |> isIdentifier then
+                        name
+                    else
+                        sprintf "``%s``" name
                 { fn with
                     Kind = String.concat "" kind |> FsFunctionKind.StringParam
-                    Name = String.concat "" name |> Some
+                    Name = name |> Some
                     Params = List.ofSeq prms
                 }
                 |> FsType.Function

--- a/test/fragments/regressions/#374-string-literal-type-argument-with-space.d.ts
+++ b/test/fragments/regressions/#374-string-literal-type-argument-with-space.d.ts
@@ -1,0 +1,18 @@
+// `☕` is recognized as `Char.IsLetterOrDigit`
+// Fixed in Fable 3
+// -> //todo: uncomment and adjust this test once upgrade to fable 3 is merged 
+
+interface A {
+    on(event: "Hello Space"): void;
+    on(event: "Hello	Tab"): void;
+    on(event: "Hello Multiple Words"): void;
+    on(event: "Hello   Multiple Spaces"): void;
+    // on(event: "Hello☕Invalid"): void;
+    // on(event: "Hello ☕ Invalid With Spaces"): void;
+    on(event: "(╯°□°）╯︵ ┻━┻"): void;
+}
+
+declare type S = 
+    | "Foo" 
+    | "Hello World" 
+    // | "Hello☕"

--- a/test/fragments/regressions/#374-string-literal-type-argument-with-space.expected.fs
+++ b/test/fragments/regressions/#374-string-literal-type-argument-with-space.expected.fs
@@ -1,0 +1,20 @@
+// ts2fable 0.8.0
+module rec #374-string-literal-type-argument-with-space
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+type [<AllowNullLiteral>] A =
+    [<Emit "$0.on('Hello Space')">] abstract on_Hello_Space: unit -> unit
+    [<Emit "$0.on('Hello	Tab')">] abstract on_Hello_Tab: unit -> unit
+    [<Emit "$0.on('Hello Multiple Words')">] abstract on_Hello_Multiple_Words: unit -> unit
+    [<Emit "$0.on('Hello   Multiple Spaces')">] abstract on_Hello___Multiple_Spaces: unit -> unit
+    // [<Emit "$0.on('Hello☕Invalid')">] abstract ``on_Hello☕Invalid``: unit -> unit
+    // [<Emit "$0.on('Hello ☕ Invalid With Spaces')">] abstract ``on_Hello_☕_Invalid_With_Spaces``: unit -> unit
+    [<Emit "$0.on('(╯°□°）╯︵ ┻━┻')">] abstract ``on_(╯°□°）╯︵_┻━┻``: unit -> unit
+
+type [<StringEnum>] [<RequireQualifiedAccess>] S =
+    | [<CompiledName "Foo">] Foo
+    | [<CompiledName "Hello World">] ``Hello World``
+    // | [<CompiledName "Hello☕">] ``Hello☕``

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -495,3 +495,7 @@ describe "transform tests" <| fun _ ->
         runRegressionTestWithComparison notEqual "#368-compare-xml-comments.fail"
     it "regression #368 compare xml comments -- indented fail" <| fun _ ->
         runRegressionTestWithComparison notEqual "#368-compare-xml-comments.indented.fail"
+
+    // https://github.com/fable-compiler/ts2fable/issues/374
+    it "string literal type argument with space" <| fun _ ->
+        runRegressionTest "#374-string-literal-type-argument-with-space"


### PR DESCRIPTION
Fix #374: Invalid function name when parameter with string literal type contains space


Note: Currently some invalid characters are recognized as valid in identifier, like `☕`.  
`Char.IsLetterOrDigit` returns wrong result. It's fixed in Fable 3, and will be fixed in ts2fable with #373. Once merged some additional tests might be commented in (-> `test\fragments\regressions\#374-string-literal-type-argument-with-space.*`)