### PR TITLE
Fix: Exception when string identifier `%`

### DIFF
--- a/src/naming.fs
+++ b/src/naming.fs
@@ -57,7 +57,12 @@ let createEnumNameParts (name: string) =
 
 let capitalize (input: string): string =
     if String.IsNullOrWhiteSpace input then ""
-    else sprintf "%c%s" (Char.ToUpper input.[0]) (input.Substring 1)
+    else 
+        // error in fable: https://github.com/fable-compiler/Fable/issues/2398
+        //    first char is `%` -> `%c` is `%` -> exception
+        // sprintf "%c%s" (Char.ToUpper input.[0]) (input.Substring 1)
+        // workaround for now:
+        (Char.ToUpper input.[0] |> string) + (input.Substring 1)
 
 let lowerFirst (input: string): string =
     if String.IsNullOrWhiteSpace input then ""

--- a/test/functionTests.fs
+++ b/test/functionTests.fs
@@ -19,6 +19,30 @@ describe "my tests" <| fun _ ->
         1 + 2
         |> equal 3
 
+describe "capitalize tests" <| fun _ ->
+    it "already capitalized" <| fun _ ->
+        capitalize "Word"
+        |> equal "Word"
+    
+    it "lowercase start" <| fun _ ->
+        capitalize "word"
+        |> equal "Word"
+
+    it "special char" <| fun _ ->
+        capitalize ">"
+        |> equal ">"
+
+    // https://github.com/fable-compiler/Fable/issues/2398
+    it "%" <| fun _ ->
+        capitalize "%"
+        |> equal "%"
+    it "%=" <| fun _ ->
+        capitalize "%="
+        |> equal "%="
+    it "=%" <| fun _ ->
+        capitalize "=%"
+        |> equal "=%"
+
 
 describe "escapeWord tests" <| fun _ ->
 


### PR DESCRIPTION
> Error: toText(...)(...) is not a function

-> Exception in `ts2fable.Name.capitalize` when input starts with `%`
Usually something like
```typescript
export type Operator =
  "==" | ... | "%" | ... | "%=" | ...;
```
(happens in packages `estree` & `babel-types`)

Error in Fable: https://github.com/fable-compiler/Fable/issues/2398
Fix until resolved: use string addition instead of formatter

Add some `capitalize` tests including `%` tests