### PR TITLE
Fix: surrounded by 4 backticks when string lit. & hyphen

### DIFF
--- a/src/naming.fs
+++ b/src/naming.fs
@@ -113,7 +113,9 @@ let escapeWord (s: string) =
     if String.IsNullOrEmpty s then ""
     else
         let s = s.Replace("'","") // remove single quotes
-        if Keywords.reserved.Contains s
+        if s.StartsWith "``" && s.EndsWith "``" then
+            s
+        elif Keywords.reserved.Contains s
             || Keywords.keywords.Contains s
             || s.IndexOfAny [|'-';'/';'$'|] <> -1 // invalid chars
             || (s.Length > 0 && Char.IsDigit (s, 0))

--- a/test/fragments/regressions/#374-string-literal-type-argument-with-space.d.ts
+++ b/test/fragments/regressions/#374-string-literal-type-argument-with-space.d.ts
@@ -10,6 +10,7 @@ interface A {
     // on(event: "Hello☕Invalid"): void;
     // on(event: "Hello ☕ Invalid With Spaces"): void;
     on(event: "(╯°□°）╯︵ ┻━┻"): void;
+    on(event: "post-require"): void;
 }
 
 declare type S = 

--- a/test/fragments/regressions/#374-string-literal-type-argument-with-space.expected.fs
+++ b/test/fragments/regressions/#374-string-literal-type-argument-with-space.expected.fs
@@ -13,6 +13,7 @@ type [<AllowNullLiteral>] A =
     // [<Emit "$0.on('Hello☕Invalid')">] abstract ``on_Hello☕Invalid``: unit -> unit
     // [<Emit "$0.on('Hello ☕ Invalid With Spaces')">] abstract ``on_Hello_☕_Invalid_With_Spaces``: unit -> unit
     [<Emit "$0.on('(╯°□°）╯︵ ┻━┻')">] abstract ``on_(╯°□°）╯︵_┻━┻``: unit -> unit
+    [<Emit "$0.on('post-require')">] abstract ``on_post-require``: unit -> unit
 
 type [<StringEnum>] [<RequireQualifiedAccess>] S =
     | [<CompiledName "Foo">] Foo


### PR DESCRIPTION
happend for something like:
```typescript
on(event: "post-require"): void;
```
(from: mocha)
Was escaped once in transform because string literal identifier with invalid token
and 2nd time in `escapeWord` because of hyphen


Note: `escapeWord` and co might need a redo:
* different allowed chars for module/type vs. function/variable name (type doesn't allow something like `$`)
* not all invalid characters are currently handled
* (further complication: `.` not allowed in type -- but in type name in `escapeWord` because might be namespace/module.type)
