### PR TITLE
Fix #382: packe name with `-` results in invalid root module name

### DIFF
--- a/src/bridge.fs
+++ b/src/bridge.fs
@@ -184,7 +184,7 @@ module internal Bridge =
         {
             // use the F# file name as the module namespace
             // TODO ensure valid name
-            Namespace = nameSpace
+            Namespace = fixRootModuleName nameSpace
             Opens =
                 [
                     "System"

--- a/src/naming.fs
+++ b/src/naming.fs
@@ -232,3 +232,7 @@ let fixNamespaceString (name: string): string =
             let parts = parts |> List.ofArray |> List.rev
             let parts = [parts.Head] @ parts.Tail |> List.map fixModuleName
             parts |> List.rev |> String.concat "."
+
+let fixRootModuleName (name: string): string =
+    name
+    |> escapeWord

--- a/test/fragments/custom/generic-type-constraints/and.expected.fs
+++ b/test/fragments/custom/generic-type-constraints/and.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.8.0
-module rec and
+module rec ``and``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/custom/generic-type-constraints/default.expected.fs
+++ b/test/fragments/custom/generic-type-constraints/default.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.8.0
-module rec default
+module rec ``default``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/custom/generic-type-constraints/function.expected.fs
+++ b/test/fragments/custom/generic-type-constraints/function.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.8.0
-module rec function
+module rec ``function``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/custom/generic-type-constraints/or.expected.fs
+++ b/test/fragments/custom/generic-type-constraints/or.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.8.0
-module rec or
+module rec ``or``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/custom/generic-type-constraints/sealed.expected.fs
+++ b/test/fragments/custom/generic-type-constraints/sealed.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.8.0
-module rec sealed
+module rec ``sealed``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#275-private-members.expected.fs
+++ b/test/fragments/regressions/#275-private-members.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.0.0
-module rec #275-private-members
+module rec ``#275-private-members``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#277-unwrap-options.expected.fs
+++ b/test/fragments/regressions/#277-unwrap-options.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.0.0
-module rec #277-unwrap-options
+module rec ``#277-unwrap-options``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#278-typeliterals-return.expected.fs
+++ b/test/fragments/regressions/#278-typeliterals-return.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.0.0
-module rec #278-typeliterals-return
+module rec ``#278-typeliterals-return``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#288-type-alias-float-number.expected.fs
+++ b/test/fragments/regressions/#288-type-alias-float-number.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.0.0
-module rec #288-type-alias-float-number
+module rec ``#288-type-alias-float-number``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#289-recursive-merge-modules.expected.fs
+++ b/test/fragments/regressions/#289-recursive-merge-modules.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.0.0
-module rec #289-recursive-merge-modules
+module rec ``#289-recursive-merge-modules``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#292-static-props.expected.fs
+++ b/test/fragments/regressions/#292-static-props.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.0.0
-module rec #292-static-props
+module rec ``#292-static-props``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#303-EmitConstructor.expected.fs
+++ b/test/fragments/regressions/#303-EmitConstructor.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.8.0
-module rec #303-EmitConstructor
+module rec ``#303-EmitConstructor``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#303-EmitIndexer.expected.fs
+++ b/test/fragments/regressions/#303-EmitIndexer.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.8.0
-module rec #303-EmitIndexer
+module rec ``#303-EmitIndexer``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#314-inline-destruct.expected.fs
+++ b/test/fragments/regressions/#314-inline-destruct.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.0.0
-module rec #314-inline-destruct
+module rec ``#314-inline-destruct``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#352-generic-type-parameter-default.expected.fs
+++ b/test/fragments/regressions/#352-generic-type-parameter-default.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.8.0
-module rec #352-generic-type-parameter-default
+module rec ``#352-generic-type-parameter-default``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#353-generic-type-parameter-default-type.expected.fs
+++ b/test/fragments/regressions/#353-generic-type-parameter-default-type.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.8.0
-module rec #353-generic-type-parameter-default-type
+module rec ``#353-generic-type-parameter-default-type``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#362-paramarray.expected.fs
+++ b/test/fragments/regressions/#362-paramarray.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.8.0
-module rec #362-paramarray
+module rec ``#362-paramarray``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#368-compare-xml-comments.fail.expected.fs
+++ b/test/fragments/regressions/#368-compare-xml-comments.fail.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.8.0
-module rec #368-compare-xml-comments.fail
+module rec ``#368-compare-xml-comments.fail``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#368-compare-xml-comments.indented.fail.expected.fs
+++ b/test/fragments/regressions/#368-compare-xml-comments.indented.fail.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.8.0
-module rec #368-compare-xml-comments.fail
+module rec ``#368-compare-xml-comments.fail``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#368-compare-xml-comments.pass.expected.fs
+++ b/test/fragments/regressions/#368-compare-xml-comments.pass.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.8.0
-module rec #368-compare-xml-comments.pass
+module rec ``#368-compare-xml-comments.pass``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#374-string-literal-type-argument-with-space.expected.fs
+++ b/test/fragments/regressions/#374-string-literal-type-argument-with-space.expected.fs
@@ -1,5 +1,5 @@
 // ts2fable 0.8.0
-module rec #374-string-literal-type-argument-with-space
+module rec ``#374-string-literal-type-argument-with-space``
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#382-package-with-hyphen-in-name-produces-invalid-module-name-with-hyphen.d.ts
+++ b/test/fragments/regressions/#382-package-with-hyphen-in-name-produces-invalid-module-name-with-hyphen.d.ts
@@ -1,0 +1,2 @@
+/// Name is created from file name -> contains several special chars and hyphen
+interface A {}

--- a/test/fragments/regressions/#382-package-with-hyphen-in-name-produces-invalid-module-name-with-hyphen.expected.fs
+++ b/test/fragments/regressions/#382-package-with-hyphen-in-name-produces-invalid-module-name-with-hyphen.expected.fs
@@ -1,0 +1,9 @@
+// ts2fable 0.0.0
+module rec ``#382-package-with-hyphen-in-name-produces-invalid-module-name-with-hyphen``
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+type [<AllowNullLiteral>] A =
+    interface end

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -501,7 +501,11 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
         runRegressionTestWithComparison notEqual "#368-compare-xml-comments.indented.fail"
 
     // https://github.com/fable-compiler/ts2fable/issues/374
-    it "string literal type argument with space" <| fun _ ->
+    it "regression #368 string literal type argument with space" <| fun _ ->
         runRegressionTest "#374-string-literal-type-argument-with-space"
+
+    // https://github.com/fable-compiler/ts2fable/issues/382
+    it "regression #382 package with hyphen in name produces invalid module name with hyphen" <| fun _ ->
+        runRegressionTest "#382-package-with-hyphen-in-name-produces-invalid-module-name-with-hyphen"
 
 )?timeout(15_000)


### PR DESCRIPTION
Fix #382: packe name with `-` -> invalid root module name

Root module name (= package name) is now treated the same way as other
identifiers
-> if hyphen or keyword the name gets surrounded with double-backticks

Note: all regression tests (`*.expected.fs` files) had to be changed:
they contain `-` in title -> has to be escaped with backticks. Their
test contents remained untouched.
Same for several other tests (F# keyword as name like `default`).