### PR TITLE
Partial fix of #386: Handle ArrayLike & PromiseLike

### DIFF
--- a/src/transform.fs
+++ b/src/transform.fs
@@ -1345,6 +1345,8 @@ let abbrevTypes =
     "Function",      "type Function = System.Action"
     "Symbol",        "type Symbol = obj"
     "TemplateStringsArray", "type TemplateStringsArray = System.Collections.Generic.IReadOnlyList<string>"
+    "ArrayLike",     "type ArrayLike<'T> = System.Collections.Generic.IList<'T>"
+    "PromiseLike",   "type PromiseLike<'T> = Fable.Core.JS.Promise<'T>"
     ] |> Map.ofList
 
 let fixFsFileOut fo =

--- a/test/fragments/regressions/#386-TS-types.d.ts
+++ b/test/fragments/regressions/#386-TS-types.d.ts
@@ -1,0 +1,4 @@
+interface I {
+    a(v: PromiseLike<string>): PromiseLike<number>;
+    b(v: ArrayLike<string>): ArrayLike<number>;
+}

--- a/test/fragments/regressions/#386-TS-types.expected.fs
+++ b/test/fragments/regressions/#386-TS-types.expected.fs
@@ -1,0 +1,13 @@
+// ts2fable 0.0.0
+module rec ``#386-TS-types``
+open System
+open Fable.Core
+open Fable.Core.JS
+
+type ArrayLike<'T> = System.Collections.Generic.IList<'T>
+type PromiseLike<'T> = Fable.Core.JS.Promise<'T>
+
+
+type [<AllowNullLiteral>] I =
+    abstract a: v: PromiseLike<string> -> PromiseLike<float>
+    abstract b: v: ArrayLike<string> -> ArrayLike<float>

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -508,4 +508,8 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
     it "regression #382 package with hyphen in name produces invalid module name with hyphen" <| fun _ ->
         runRegressionTest "#382-package-with-hyphen-in-name-produces-invalid-module-name-with-hyphen"
 
+    // https://github.com/fable-compiler/ts2fable/issues/386
+    it "regression #386 TS types" <| fun _ ->
+        runRegressionTest "#386-TS-types"
+
 )?timeout(15_000)


### PR DESCRIPTION
Partial fix of #386: Handle ArrayLike & PromiseLike

`ArrayLike` -> `System.Collections.Generic.IList<'T>`
`PromiseLike` -> `Fable.Core.JS.Promise<'T>`