### PR TITLE
Remove hack to use regex with named groups

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "fable": {
-      "version": "3.1.4",
+      "version": "3.1.11",
       "commands": [
         "fable"
       ]


### PR DESCRIPTION
Fable was updated to handle named capture groups for regexes
-> use .NET group accessor instead of JS dynamic typing hack