### PR TITLE
Fix #393: Mutable variables become immutable

### DIFF
--- a/src/read.fs
+++ b/src/read.fs
@@ -284,7 +284,7 @@ let hasModifier (kind: SyntaxKind) (modifiers: ModifiersArray option) =
     | Some mds -> mds |> Seq.exists (fun md -> md.kind = kind)
 
 let isConst (nd: Node): bool =
-    (int nd.flags) ||| (int NodeFlags.Const) <> 0
+    nd.flags.HasFlag NodeFlags.Const
 
 let isNamespace (nd: Node): bool =
     nd.getChildren() |> Seq.exists (fun nd -> nd.kind = SyntaxKind.NamespaceKeyword)
@@ -298,7 +298,7 @@ let readVariable (checker: TypeChecker) (vb: VariableStatement) =
             HasDeclare = hasModifier SyntaxKind.DeclareKeyword vb.modifiers || hasModifier SyntaxKind.ExportKeyword vb.modifiers
             Name = vd.name |> getBindingName |> Option.defaultValue "unsupported_pattern"
             Type = vd.``type`` |> Option.map (readTypeNode checker) |> Option.defaultValue (simpleType "obj")
-            IsConst = isConst vd
+            IsConst = isConst (vb.declarationList)  // const is specified before all declarations -> part of list
             IsStatic = hasModifier SyntaxKind.StaticKeyword vd.modifiers
             Accessibility = getAccessibility vb.modifiers
         }

--- a/test/fragments/monaco/variableInModule.fs
+++ b/test/fragments/monaco/variableInModule.fs
@@ -9,7 +9,7 @@ let [<Import("*","variableInModule")>] monaco: Monaco.IExports = jsNative
 module Monaco =
 
     type [<AllowNullLiteral>] IExports =
-        abstract EditorType: IExportsEditorType
+        abstract EditorType: IExportsEditorType with get, set
 
     type [<AllowNullLiteral>] IDisposable =
         abstract dispose: unit -> unit

--- a/test/fragments/reactxp/duplicatedVariableExports.fs
+++ b/test/fragments/reactxp/duplicatedVariableExports.fs
@@ -9,35 +9,35 @@ let [<Import("*","reactxp")>] reactXP: ReactXP.IExports = jsNative
 module ReactXP =
 
     type [<AllowNullLiteral>] IExports =
-        abstract Accessibility: RXInterfaces.Accessibility
-        abstract ActivityIndicator: obj
-        abstract Alert: RXInterfaces.Alert
-        abstract App: RXInterfaces.App
-        abstract Button: obj
-        abstract Picker: obj
-        abstract Clipboard: RXInterfaces.Clipboard
-        abstract GestureView: obj
-        abstract Image: RXInterfaces.ImageConstructor
-        abstract Input: RXInterfaces.Input
-        abstract International: RXInterfaces.International
-        abstract Link: obj
-        abstract Linking: RXInterfaces.Linking
-        abstract Location: RXInterfaces.Location
-        abstract Modal: RXInterfaces.Modal
-        abstract Network: RXInterfaces.Network
-        abstract Platform: RXInterfaces.Platform
-        abstract Popup: RXInterfaces.Popup
-        abstract ScrollView: RXInterfaces.ScrollViewConstructor
-        abstract StatusBar: RXInterfaces.StatusBar
-        abstract Storage: RXInterfaces.Storage
-        abstract Styles: RXInterfaces.Styles
-        abstract Text: obj
-        abstract TextInput: obj
-        abstract UserInterface: RXInterfaces.UserInterface
-        abstract UserPresence: RXInterfaces.UserPresence
-        abstract View: obj
-        abstract WebView: RXInterfaces.WebViewConstructor
-        abstract __spread: obj option
+        abstract Accessibility: RXInterfaces.Accessibility with get, set
+        abstract ActivityIndicator: obj with get, set
+        abstract Alert: RXInterfaces.Alert with get, set
+        abstract App: RXInterfaces.App with get, set
+        abstract Button: obj with get, set
+        abstract Picker: obj with get, set
+        abstract Clipboard: RXInterfaces.Clipboard with get, set
+        abstract GestureView: obj with get, set
+        abstract Image: RXInterfaces.ImageConstructor with get, set
+        abstract Input: RXInterfaces.Input with get, set
+        abstract International: RXInterfaces.International with get, set
+        abstract Link: obj with get, set
+        abstract Linking: RXInterfaces.Linking with get, set
+        abstract Location: RXInterfaces.Location with get, set
+        abstract Modal: RXInterfaces.Modal with get, set
+        abstract Network: RXInterfaces.Network with get, set
+        abstract Platform: RXInterfaces.Platform with get, set
+        abstract Popup: RXInterfaces.Popup with get, set
+        abstract ScrollView: RXInterfaces.ScrollViewConstructor with get, set
+        abstract StatusBar: RXInterfaces.StatusBar with get, set
+        abstract Storage: RXInterfaces.Storage with get, set
+        abstract Styles: RXInterfaces.Styles with get, set
+        abstract Text: obj with get, set
+        abstract TextInput: obj with get, set
+        abstract UserInterface: RXInterfaces.UserInterface with get, set
+        abstract UserPresence: RXInterfaces.UserPresence with get, set
+        abstract View: obj with get, set
+        abstract WebView: RXInterfaces.WebViewConstructor with get, set
+        abstract __spread: obj option with get, set
 
     type Accessibility =
         RXInterfaces.Accessibility

--- a/test/fragments/reactxp/multiple/ReactXP.fs
+++ b/test/fragments/reactxp/multiple/ReactXP.fs
@@ -41,7 +41,7 @@ module __web_ReactXP =
     module ReactXP =
 
         type [<AllowNullLiteral>] IExports =
-            abstract __spread: obj option
+            abstract __spread: obj option with get, set
 
 module __windows_App =
     type ComponentProvider = React_native.ComponentProvider

--- a/test/fragments/regressions/#393-mutable-variables-become-immutable.d.ts
+++ b/test/fragments/regressions/#393-mutable-variables-become-immutable.d.ts
@@ -1,0 +1,36 @@
+export module M {
+    /** `var` -> mutable */
+    var v2: number;
+    /** `let` -> mutable */
+    let l1: number;
+    /** `const` -> immutable */
+    const c1: number;
+}
+
+export namespace N {
+    /** `var` -> mutable */
+    var v2: number;
+    /** `let` -> mutable */
+    let l1: number;
+    /** `const` -> immutable */
+    const c1: number;
+}
+
+/** 
+ * `var` -> mutable 
+ * 
+ * BUT: 
+ * > error FS0874: Mutable 'let' bindings can't be recursive or defined in recursive modules or namespaces
+ * -> keep immutable
+ * */
+export var v2: number;
+/** 
+ * `let` -> mutable 
+ * 
+ * BUT: 
+ * > error FS0874: Mutable 'let' bindings can't be recursive or defined in recursive modules or namespaces
+ * -> keep immutable
+ * */
+export let l1: number;
+/** `const` -> immutable */
+export const c1: number;

--- a/test/fragments/regressions/#393-mutable-variables-become-immutable.expected.fs
+++ b/test/fragments/regressions/#393-mutable-variables-become-immutable.expected.fs
@@ -1,0 +1,47 @@
+// ts2fable 0.0.0
+module rec ``#393-mutable-variables-become-immutable``
+open System
+open Fable.Core
+open Fable.Core.JS
+
+let [<Import("M","#393-mutable-variables-become-immutable")>] m: M.IExports = jsNative
+let [<Import("N","#393-mutable-variables-become-immutable")>] n: N.IExports = jsNative
+/// <summary>
+/// <c>var</c> -> mutable 
+/// 
+/// BUT: 
+/// > error FS0874: Mutable 'let' bindings can't be recursive or defined in recursive modules or namespaces
+/// -> keep immutable
+/// </summary>
+let [<Import("v2","#393-mutable-variables-become-immutable")>] v2: float = jsNative
+/// <summary>
+/// <c>let</c> -> mutable 
+/// 
+/// BUT: 
+/// > error FS0874: Mutable 'let' bindings can't be recursive or defined in recursive modules or namespaces
+/// -> keep immutable
+/// </summary>
+let [<Import("l1","#393-mutable-variables-become-immutable")>] l1: float = jsNative
+/// <summary><c>const</c> -> immutable</summary>
+let [<Import("c1","#393-mutable-variables-become-immutable")>] c1: float = jsNative
+
+
+module M =
+
+    type [<AllowNullLiteral>] IExports =
+        /// <summary><c>var</c> -> mutable</summary>
+        abstract v2: float with get, set
+        /// <summary><c>let</c> -> mutable</summary>
+        abstract l1: float with get, set
+        /// <summary><c>const</c> -> immutable</summary>
+        abstract c1: float
+
+module N =
+
+    type [<AllowNullLiteral>] IExports =
+        /// <summary><c>var</c> -> mutable</summary>
+        abstract v2: float with get, set
+        /// <summary><c>let</c> -> mutable</summary>
+        abstract l1: float with get, set
+        /// <summary><c>const</c> -> immutable</summary>
+        abstract c1: float

--- a/test/fragments/regressions/#394-comments-on-variables-in-modules.expected.fs
+++ b/test/fragments/regressions/#394-comments-on-variables-in-modules.expected.fs
@@ -14,9 +14,9 @@ module M =
 
     type [<AllowNullLiteral>] IExports =
         /// var
-        abstract v1: float
+        abstract v1: float with get, set
         /// let
-        abstract l1: float
+        abstract l1: float with get, set
         /// const
         abstract c1: float
 
@@ -25,8 +25,8 @@ module N =
 
     type [<AllowNullLiteral>] IExports =
         /// var
-        abstract v1: float
+        abstract v1: float with get, set
         /// let
-        abstract l1: float
+        abstract l1: float with get, set
         /// const
         abstract c1: float

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -524,4 +524,8 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
     it "regression #394 Comments on Variables in Modules" <| fun _ ->
         runRegressionTest "#394-comments-on-variables-in-modules"
 
+    // https://github.com/fable-compiler/ts2fable/issues/393
+    it "regression #393 Mutable Variables become immutable" <| fun _ ->
+        runRegressionTest "#393-mutable-variables-become-immutable"
+
 )?timeout(15_000)


### PR DESCRIPTION
Works with variables in modules & namespaces.

Doesn't work with top-level variables:
```typescript
export let v: number;
```
`v` is mutable and should be converted into:
```fsharp
let [<Import(...)>] mutable v: float = jsNative
```
BUT: ts2fable places everything in a recursive module:
```fsharp
module rec Name
open System
//...
let [<Import(...)>] mutable v: float = jsNative
```
In a rec module, mutable let bindings aren't allowed:
> error FS0874: Mutable 'let' bindings can't be recursive or defined in
recursive modules or namespaces

-> would require change of generated code for top-level variables.
Instead these variables are still immutable.