### PR TITLE
Convert Anonymous Object Type into Anonymous Records & Fix #400

### DIFF
--- a/src/transform.fs
+++ b/src/transform.fs
@@ -911,7 +911,8 @@ let extractTypeLiterals(f: FsFile): FsFile =
     let MaxMembers = 4
     let (|TypeLiteralToConvert|_|) =
         function
-        | FsType.TypeLiteral tl when tl.Members.Length > MaxMembers -> Some tl
+        | FsType.TypeLiteral tl when tl.Members |> List.isEmpty || tl.Members.Length > MaxMembers -> 
+            Some tl
         | _ -> None
 
     /// the goal is to create interface types with 'pretty' names like '$(Class)$(Method)Return'.

--- a/src/transform.fs
+++ b/src/transform.fs
@@ -925,6 +925,17 @@ let extractTypeLiterals(f: FsFile): FsFile =
         //       See https://github.com/fable-compiler/ts2fable/issues/415
         | FsType.TypeLiteral tl when tl.Members |> List.exists isIndexer ->
             Some tl
+        // | FsType.TypeLiteral tl when Config.ConvertPropertyFunctions ->
+        //     printfn "TypeLiteral=%A" tl
+        //     None
+        | FsType.TypeLiteral tl when Config.ConvertPropertyFunctions && tl.Members |> List.exists (function | FsType.Property p -> FsType.isFunction p.Type | _ -> false) -> 
+            // `class Appwrite { account: { createDocument: (name: string) => Document; }; }`
+            // `createDocument` is usually converted into property:
+            // `abstract account: {| createDocument: string -> Document |} with get, set`
+            // but with `ConvertPropertyFunctions` enabled, `createDocument` should turn into a function:
+            // `abstract createDocument: name: string -> Document`
+            // -> extract `account` into interface
+            Some tl
         | _ -> None
 
     /// the goal is to create interface types with 'pretty' names like '$(Class)$(Method)Return'.

--- a/src/transform.fs
+++ b/src/transform.fs
@@ -1111,14 +1111,17 @@ let extractTypeLiterals(f: FsFile): FsFile =
             m
             // 1: replace occurences of TypeLiterals with references to the generated types
             |> fixOneModule (fun ns tp ->
-                match tp with
-                | TypeLiteralToConvert tl ->
-
+                let replace (tl: FsTypeLiteral) =
                     let extractedInterface = replaceLiteral ns tl
                     match extractedInterface.TypeParameters with
                     | [ ] ->
                         simpleType (extractedInterface.Name)
                     | tp -> FsType.Generic({ Type = simpleType (extractedInterface.Name); TypeParameters = tp })
+
+                match tp with
+                | TypeLiteralToConvert tl -> replace tl
+                | FsType.TypeLiteral ({ Members = [ FsType.Enum _ ] } as tl) ->
+                    replace tl
                 | _ -> tp
             )
             // 2: append the generated types to the module

--- a/src/transform.fs
+++ b/src/transform.fs
@@ -1008,7 +1008,7 @@ let extractTypeLiterals(f: FsFile): FsFile =
                         [it2] @ (List.ofSeq newTypes) // append new types
                     | FsType.Alias al ->
                         match al.Type with
-                        | FsType.Union un ->
+                        | FsType.Union un when un.Types.Length > 1 ->
                             let newTypes = ResizeArray()
                             let un =
                                 { un with
@@ -1027,7 +1027,7 @@ let extractTypeLiterals(f: FsFile): FsFile =
                                 }
                             let al = FsType.Alias {al with Type = un |> FsType.Union}
                             [al] @ (List.ofSeq newTypes)
-                        | TypeLiteralToConvert tl ->
+                        | FsType.TypeLiteral tl ->
                             {
                                 Attributes = []
                                 Comments = al.Comments

--- a/src/transformComments.fs
+++ b/src/transformComments.fs
@@ -267,12 +267,11 @@ let private (|TransformMultilineCode|_|) (lines: string list) =
                     | "" -> None
                     | lang -> Some lang
                 let startTag = 
-                    // sandcastle understands language attribute
-                    // https://ewsoftware.github.io/SHFB/html/7f03ba39-09f8-4320-bdbd-ed31a3bd885f.htm
+                    // Ionide understands `lang` attribute
                     match lang with
                     | None -> "<code>"
                     | Some lang ->
-                        sprintf "<code language=\"%s\">" lang
+                        sprintf "<code lang=\"%s\">" lang
 
                 startTag :: code @ ["</code>"]
 

--- a/test/fragments/babylonjs/SceneLoader.ImportMeshAsync.expected.fs
+++ b/test/fragments/babylonjs/SceneLoader.ImportMeshAsync.expected.fs
@@ -41,10 +41,4 @@ module BABYLON =
         /// Test:
         /// 1) the callback 'onProgress' should not be Option<Option<_>>. Instead it should be an optional parameter of type function.
         /// 2) the return value should be Promise<Interface>, not Promise<obj>. (Currently it generates 'TypeLiteral_01', would be great if it generated a better-named interface like 'SceneLoaderImportMeshAsyncReturn')
-        abstract ImportMeshAsync: meshNames: obj option * rootUrl: string * ?sceneFilename: string * ?scene: Scene * ?onProgress: (SceneLoaderProgressEvent -> unit) * ?pluginExtension: string -> Promise<SceneLoaderStaticImportMeshAsyncPromise>
-
-    type [<AllowNullLiteral>] SceneLoaderStaticImportMeshAsyncPromise =
-        abstract meshes: ResizeArray<AbstractMesh> with get, set
-        abstract particleSystems: ResizeArray<IParticleSystem> with get, set
-        abstract skeletons: ResizeArray<Skeleton> with get, set
-        abstract animationGroups: ResizeArray<AnimationGroup> with get, set
+        abstract ImportMeshAsync: meshNames: obj option * rootUrl: string * ?sceneFilename: string * ?scene: Scene * ?onProgress: (SceneLoaderProgressEvent -> unit) * ?pluginExtension: string -> Promise<{| meshes: ResizeArray<AbstractMesh>; particleSystems: ResizeArray<IParticleSystem>; skeletons: ResizeArray<Skeleton>; animationGroups: ResizeArray<AnimationGroup> |}>

--- a/test/fragments/babylonjs/Stage.PrivateCtor.expected.fs
+++ b/test/fragments/babylonjs/Stage.PrivateCtor.expected.fs
@@ -28,7 +28,7 @@ module BABYLON =
     /// Expected FS output: 'Stage' with 'registerStep' and 'clear', 'StageStatic' with the static Create method
     /// **********
     type [<AllowNullLiteral>] Stage<'T> =
-        inherit Array<StageArray<'T>>
+        inherit Array<{| index: float; ``component``: ISceneComponent; action: 'T |}>
         /// <summary>Registers a step in an ordered way in the targeted stage.</summary>
         /// <param name="index">Defines the position to register the step in</param>
         /// <param name="component">Defines the component attached to the step</param>
@@ -45,8 +45,3 @@ module BABYLON =
         /// <summary>Creates a new Stage.</summary>
         /// <returns>A new instance of a Stage</returns>
         abstract Create: unit -> Stage<'T>
-
-    type [<AllowNullLiteral>] StageArray<'T> =
-        abstract index: float with get, set
-        abstract ``component``: ISceneComponent with get, set
-        abstract action: 'T with get, set

--- a/test/fragments/custom/comments/transformToXml.expected.fs
+++ b/test/fragments/custom/comments/transformToXml.expected.fs
@@ -26,7 +26,7 @@ open Fable.Core.JS
 /// </code>
 /// 
 /// Multi line code with language:
-/// <code language="fsharp">
+/// <code lang="fsharp">
 /// let text = "Hello fsharp"
 /// printfn "%s" text
 /// </code>

--- a/test/fragments/custom/type-literal-indexer.d.ts
+++ b/test/fragments/custom/type-literal-indexer.d.ts
@@ -1,0 +1,18 @@
+export function fIndexerOut(): {
+    [key: string]: string;
+};
+export function fIndexerIn(i: {
+    [key: string]: string;
+}): void;
+export function fIndexerIn2(i: {
+    [key: string]: string;
+    [index: number]: string;
+}): void;
+/**
+ * Some description
+ * 
+ * @remarks some remarks
+ */
+export function fIndexerIn3WithComments(i: {
+    [key: string]: string;
+}): void;

--- a/test/fragments/custom/type-literal-indexer.expected.fs
+++ b/test/fragments/custom/type-literal-indexer.expected.fs
@@ -1,0 +1,88 @@
+// ts2fable 0.0.0
+module rec ``type-literal-indexer``
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+type [<AllowNullLiteral>] IExports =
+    abstract fIndexerOut: unit -> FIndexerOutReturn
+    abstract fIndexerIn: i: FIndexerInI -> unit
+    abstract fIndexerIn2: i: FIndexerIn2I -> unit
+    /// <summary>Some description</summary>
+    /// <remarks>some remarks</remarks>
+    abstract fIndexerIn3WithComments: i: FIndexerIn3WithCommentsI -> unit
+
+type [<AllowNullLiteral>] FIndexerOutReturn =
+    [<EmitIndexer>] abstract Item: key: string -> string with get, set
+
+/// <summary>
+/// Typescript interface contains an <see href="https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures">index signature</see> (like <c>{ [key:string]: string }</c>).  
+/// Unlike an indexer in F#, index signatures index over a type's members. 
+/// 
+/// As such an index signature cannot be implemented via regular F# Indexer (<c>Item</c> property),
+/// but instead by just specifying fields.
+/// 
+/// Easiest way to declare such a type is with an Anonymous Record and force it into the function.  
+/// For example:  
+/// <code language="fsharp">
+/// type I =
+///     [&lt;EmitIndexer&gt;]
+///     abstract Item: string -&gt; string
+/// let f (i: I) = jsNative
+/// 
+/// let t = {| Value1 = "foo"; Value2 = "bar" |}
+/// f (!! t)
+/// </code>
+/// </summary>
+type [<AllowNullLiteral>] FIndexerInI =
+    [<EmitIndexer>] abstract Item: key: string -> string with get, set
+
+/// <summary>
+/// Typescript interface contains an <see href="https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures">index signature</see> (like <c>{ [key:string]: string }</c>).  
+/// Unlike an indexer in F#, index signatures index over a type's members. 
+/// 
+/// As such an index signature cannot be implemented via regular F# Indexer (<c>Item</c> property),
+/// but instead by just specifying fields.
+/// 
+/// Easiest way to declare such a type is with an Anonymous Record and force it into the function.  
+/// For example:  
+/// <code language="fsharp">
+/// type I =
+///     [&lt;EmitIndexer&gt;]
+///     abstract Item: string -&gt; string
+/// let f (i: I) = jsNative
+/// 
+/// let t = {| Value1 = "foo"; Value2 = "bar" |}
+/// f (!! t)
+/// </code>
+/// </summary>
+type [<AllowNullLiteral>] FIndexerIn2I =
+    [<EmitIndexer>] abstract Item: key: string -> string with get, set
+    [<EmitIndexer>] abstract Item: index: float -> string with get, set
+
+/// <summary>
+/// Typescript interface contains an <see href="https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures">index signature</see> (like <c>{ [key:string]: string }</c>).  
+/// Unlike an indexer in F#, index signatures index over a type's members. 
+/// 
+/// As such an index signature cannot be implemented via regular F# Indexer (<c>Item</c> property),
+/// but instead by just specifying fields.
+/// 
+/// Easiest way to declare such a type is with an Anonymous Record and force it into the function.  
+/// For example:  
+/// <code language="fsharp">
+/// type I =
+///     [&lt;EmitIndexer&gt;]
+///     abstract Item: string -&gt; string
+/// let f (i: I) = jsNative
+/// 
+/// let t = {| Value1 = "foo"; Value2 = "bar" |}
+/// f (!! t)
+/// </code>
+/// </summary>
+type [<AllowNullLiteral>] FIndexerIn3WithCommentsI =
+    [<EmitIndexer>] abstract Item: key: string -> string with get, set
+

--- a/test/fragments/custom/type-literal-indexer.expected.fs
+++ b/test/fragments/custom/type-literal-indexer.expected.fs
@@ -28,7 +28,7 @@ type [<AllowNullLiteral>] FIndexerOutReturn =
 /// 
 /// Easiest way to declare such a type is with an Anonymous Record and force it into the function.  
 /// For example:  
-/// <code language="fsharp">
+/// <code lang="fsharp">
 /// type I =
 ///     [&lt;EmitIndexer&gt;]
 ///     abstract Item: string -&gt; string
@@ -50,7 +50,7 @@ type [<AllowNullLiteral>] FIndexerInI =
 /// 
 /// Easiest way to declare such a type is with an Anonymous Record and force it into the function.  
 /// For example:  
-/// <code language="fsharp">
+/// <code lang="fsharp">
 /// type I =
 ///     [&lt;EmitIndexer&gt;]
 ///     abstract Item: string -&gt; string
@@ -73,7 +73,7 @@ type [<AllowNullLiteral>] FIndexerIn2I =
 /// 
 /// Easiest way to declare such a type is with an Anonymous Record and force it into the function.  
 /// For example:  
-/// <code language="fsharp">
+/// <code lang="fsharp">
 /// type I =
 ///     [&lt;EmitIndexer&gt;]
 ///     abstract Item: string -&gt; string

--- a/test/fragments/custom/type-literal.d.ts
+++ b/test/fragments/custom/type-literal.d.ts
@@ -1,0 +1,174 @@
+/** Type Alias -> interface, NOT anonymous record */
+export type NoUnion = { v1: string }
+/** Anonymous Record */
+export type Union1 = string | { v1: string }
+/** less than 5 members -> Anonymous Record */
+export type Union4 = string | { v1: string, v2: number, v3: number, v4: string }
+/** more than 4 members -> Interface */
+export type Union5 = string | { v1: string, v2: number, v3: number, v4: string, v5: string }
+
+/** 
+ * Source: (React)[https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87]
+ * 
+ * Similar to `fragments/react/f1` (but not generic) 
+ */
+export type UnionBivarianceHack = string | { bivarianceHack(instance: string | null): void }["bivarianceHack"]
+/**
+ * Source: (React)[https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87]
+ */
+export type RefCallback<T> = { bivarianceHack(instance: T | null): void }["bivarianceHack"]; 
+
+
+/** neither interface nor anon record */
+export function f0_0( v: string ): number
+/** Input: Anon record; Return: Anon record */
+export function f1_1( v: { v1: string } ): { v1: number }
+/** Input: Anon record; Return: Anon record */
+export function f2_2( v: { v1: string, v2: number } ): { v1: number, v2: string }
+/** Input: Anon record; Return: Anon record */
+export function f3_3( v: { v1: string, v2: number, v3: string } ): { v1: number, v2: string, v3: string }
+/** Input: Anon record; Return: Anon record */
+export function f4_4( v: { v1: string, v2: number, v3: string, v4: string } ): { v1: number, v2: string, v3: string, v4: number }
+/** Input: interface; Return: interface */
+export function f5_5( v: { v1: string, v2: number, v3: string, v4: string, v5: string } ): { v1: number, v2: string, v3: string, v4: number, v5: string }
+/** Input: anon record, interface; Return: anon record */
+export function f2_5_3( v1: { v1: string, v2: number }, v2: { v1: number, v2: string, v3: string, v4: number, v5: string } ): { v1: number, v2: string, v3: string }
+
+
+/** Input: anon record; Return: anon record */
+export function fOptional2_Optional3( v1: { name: string, birthday?: number } ): { name: string, age?: number, id: number }
+
+/** Input: anon record; Return: anon record */
+export function ff2_2( v1: { value: string, f: ( value: string ) => string } ): { result: string, f: ( value: string, id: number ) => string }
+/** Input: interface; Return: anon interface */
+export function ff2_2( v1: { value: string, f: ( value: string ) => string, v2: number, v3: number, v4: string, v5: string } ): { result: string, f: ( value: string, id: number ) => string, v2: number, v3: number, v4: string, v5: string }
+
+/** Anon record */
+export const c1: { v1: string }
+/** Anon record */
+export const c4: { v1: string, v2: number, v3: number, v4: string }
+/** interface */
+export const c5: { v1: string, v2: number, v3: number, v4: string, v5: string }
+
+/** Anon record */
+export let l1: { v1: string }
+/** Anon record */
+export let l4: { v1: string, v2: number, v3: number, v4: string }
+/** interface */
+export let l5: { v1: string, v2: number, v3: number, v4: string, v5: string }
+
+/** Nested Anon records */
+export const cn1: {
+  v1: string,
+  v2: {
+    v2_1: string,
+    v2_2: {
+      v2_2_1: string,
+      v2_2_2: number,
+      v2_2_3: string,
+    },
+    v2_3: {
+      v2_3_1: string,
+      v2_3_2: string,
+    },
+    v2_4: string,
+  },
+  v3: number,
+}
+/** Nested Anon records & Interfaces */
+export const cn2: {
+  v1: string,
+  v2: {   // anon record
+    v2_1: string,
+    v2_2: { // interface
+      v2_2_1: string,
+      v2_2_2: number,
+      v2_2_3: string,
+      v2_2_4: string,
+      v2_2_5: number,
+    },
+    v2_3: { // anon record
+      v2_3_1: string,
+      v2_3_2: string
+    },
+    v2_4: string
+  },
+  v3: { // interface
+    v3_1: string,
+    v3_2: number,
+    v3_3: { // anon record
+      v3_3_1: string,
+      v3_3_2: { // interface
+        v3_3_2_1: string,
+        v3_3_2_2: number,
+        v3_3_2_3: string,
+        v3_3_2_4: number,
+        v3_3_2_5: string,
+        v3_3_2_6: string,
+      },
+      v3_3_3: string,
+    },
+    v3_4: string,
+    v3_5: number,
+  }
+}
+
+export interface I1 {
+  /** Anon Record */
+  l1: { v1: string }
+  /** Interface */
+  l5: { v1: string, v2: number, v3: number, v4: string, v5: string }
+  /** Anon Record */
+  readonly c1: { v1: string }
+  /** Interface */
+  readonly c5: { v1: string, v2: number, v3: number, v4: string, v5: string }
+  /** Anon Record */
+  f1( v1: { v1: string } ): { v1: string }
+  /** Interface */
+  f5( v1: { v1: string, v2: number, v3: number, v4: string, v5: string }): { v1: string, v2: number, v3: number, v4: string, v5: string }
+}
+
+export type T1 = {
+  /** Anon Record */
+  l1: { v1: string }
+  /** Interface */
+  l5: { v1: string, v2: number, v3: number, v4: string, v5: string }
+  /** Anon Record */
+  readonly c1: { v1: string }
+  /** Interface */
+  readonly c5: { v1: string, v2: number, v3: number, v4: string, v5: string }
+  /** Anon Record */
+  f1( v1: { v1: string } ): { v1: string }
+  /** Interface */
+  f5( v1: { v1: string, v2: number, v3: number, v4: string, v5: string }): { v1: string, v2: number, v3: number, v4: string, v5: string }
+}
+
+export namespace N1 {
+  /** Anon Record */
+  let l1: { v1: string }
+  /** Interface */
+  let l5: { v1: string, v2: number, v3: number, v4: string, v5: string }
+  /** Anon Record */
+  const c1: { v1: string }
+  /** Interface */
+  const c5: { v1: string, v2: number, v3: number, v4: string, v5: string }
+  /** Anon Record */
+  function f1( v1: { v1: string } ): { v1: string }
+  /** Interface */
+  function f5( v1: { v1: string, v2: number, v3: number, v4: string, v5: string }): { v1: string, v2: number, v3: number, v4: string, v5: string }
+}
+
+export class C1 {
+  /** Anon Record */
+  l1: { v1: string }
+  /** Interface */
+  l5: { v1: string, v2: number, v3: number, v4: string, v5: string }
+  /** Anon Record */
+  readonly c1: { v1: string }
+  /** Interface */
+  readonly c5: { v1: string, v2: number, v3: number, v4: string, v5: string }
+  /** Anon Record */
+  f1( v1: { v1: string } ): { v1: string }
+  /** Interface */
+  f5( v1: { v1: string, v2: number, v3: number, v4: string, v5: string }): { v1: string, v2: number, v3: number, v4: string, v5: string }
+}

--- a/test/fragments/custom/type-literal.d.ts
+++ b/test/fragments/custom/type-literal.d.ts
@@ -8,13 +8,13 @@ export type Union4 = string | { v1: string, v2: number, v3: number, v4: string }
 export type Union5 = string | { v1: string, v2: number, v3: number, v4: string, v5: string }
 
 /** 
- * Source: (React)[https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87]
+ * Source: [React](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87)
  * 
  * Similar to `fragments/react/f1` (but not generic) 
  */
 export type UnionBivarianceHack = string | { bivarianceHack(instance: string | null): void }["bivarianceHack"]
 /**
- * Source: (React)[https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87]
+ * Source: [React](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87)
  */
 export type RefCallback<T> = { bivarianceHack(instance: T | null): void }["bivarianceHack"]; 
 
@@ -172,3 +172,24 @@ export class C1 {
   /** Interface */
   f5( v1: { v1: string, v2: number, v3: number, v4: string, v5: string }): { v1: string, v2: number, v3: number, v4: string, v5: string }
 }
+
+/** 
+ * NOT a Anonymous Record, instead Union type (read as TypeLiteral)
+ * 
+ * source: [Mocha](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ab5329620abcfa7ffc990d93d45165b8e51a55ca/types/mocha/index.d.ts#L165)
+ */
+export const state: 'failed' | 'passed' | undefined
+
+/** 
+ * read as Type Literal 
+ * BUT: Input & Output must be extracted into Union
+ */
+export function e1(v: "Alpha" | "Beta"): "Gamma" | "Delta"
+
+/** 
+ * read as Type Literal 
+ * BUT: must be printed as Union
+ */
+export type E1 = 
+    | "Alpha" 
+    | "Beta" 

--- a/test/fragments/custom/type-literal.expected.fs
+++ b/test/fragments/custom/type-literal.expected.fs
@@ -1,5 +1,8 @@
 // ts2fable 0.0.0
 module rec ``type-literal``
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
 open System
 open Fable.Core
 open Fable.Core.JS
@@ -46,7 +49,7 @@ type [<AllowNullLiteral>] IExports =
     /// Input: anon record; Return: anon record
     abstract fOptional2_Optional3: v1: {| name: string; birthday: float option |} -> {| name: string; age: float option; id: float |}
     /// Input: anon record; Return: anon record
-    abstract ff2_2: v1: {| value: string; f: (string -> string) |} -> {| result: string; f: (string -> float -> string) |}
+    abstract ff2_2: v1: {| value: string; f: string -> string |} -> {| result: string; f: string -> float -> string |}
     /// Input: interface; Return: anon interface
     abstract ff2_2: v1: Ff2_2V1 -> Ff2_2Return
     abstract C1: C1Static

--- a/test/fragments/custom/type-literal.expected.fs
+++ b/test/fragments/custom/type-literal.expected.fs
@@ -1,0 +1,258 @@
+// ts2fable 0.0.0
+module rec ``type-literal``
+open System
+open Fable.Core
+open Fable.Core.JS
+
+let [<Import("N1","type-literal")>] n1: N1.IExports = jsNative
+/// Anon record
+let [<Import("c1","type-literal")>] c1: {| v1: string |} = jsNative
+/// Anon record
+let [<Import("c4","type-literal")>] c4: {| v1: string; v2: float; v3: float; v4: string |} = jsNative
+/// interface
+let [<Import("c5","type-literal")>] c5: C5 = jsNative
+/// Anon record
+let [<Import("l1","type-literal")>] l1: {| v1: string |} = jsNative
+/// Anon record
+let [<Import("l4","type-literal")>] l4: {| v1: string; v2: float; v3: float; v4: string |} = jsNative
+/// interface
+let [<Import("l5","type-literal")>] l5: C5 = jsNative
+/// Nested Anon records
+let [<Import("cn1","type-literal")>] cn1: {| v1: string; v2: {| v2_1: string; v2_2: {| v2_2_1: string; v2_2_2: float; v2_2_3: string |}; v2_3: {| v2_3_1: string; v2_3_2: string |}; v2_4: string |}; v3: float |} = jsNative
+/// Nested Anon records & Interfaces
+let [<Import("cn2","type-literal")>] cn2: {| v1: string; v2: {| v2_1: string; v2_2: Cn2V2V2_2; v2_3: {| v2_3_1: string; v2_3_2: string |}; v2_4: string |}; v3: Cn2V3 |} = jsNative
+
+type [<AllowNullLiteral>] IExports =
+    /// neither interface nor anon record
+    abstract f0_0: v: string -> float
+    /// Input: Anon record; Return: Anon record
+    abstract f1_1: v: {| v1: string |} -> {| v1: float |}
+    /// Input: Anon record; Return: Anon record
+    abstract f2_2: v: {| v1: string; v2: float |} -> {| v1: float; v2: string |}
+    /// Input: Anon record; Return: Anon record
+    abstract f3_3: v: {| v1: string; v2: float; v3: string |} -> {| v1: float; v2: string; v3: string |}
+    /// Input: Anon record; Return: Anon record
+    abstract f4_4: v: {| v1: string; v2: float; v3: string; v4: string |} -> {| v1: float; v2: string; v3: string; v4: float |}
+    /// Input: interface; Return: interface
+    abstract f5_5: v: F5_5V -> F5_5Return
+    /// Input: anon record, interface; Return: anon record
+    abstract f2_5_3: v1: {| v1: string; v2: float |} * v2: F2_5_3V2 -> {| v1: float; v2: string; v3: string |}
+    /// Input: anon record; Return: anon record
+    abstract fOptional2_Optional3: v1: {| name: string; birthday: float option |} -> {| name: string; age: float option; id: float |}
+    /// Input: anon record; Return: anon record
+    abstract ff2_2: v1: {| value: string; f: (string -> string) |} -> {| result: string; f: (string -> float -> string) |}
+    /// Input: interface; Return: anon interface
+    abstract ff2_2: v1: Ff2_2V1 -> Ff2_2Return
+    abstract C1: C1Static
+
+type [<AllowNullLiteral>] F5_5V =
+    abstract v1: string with get, set
+    abstract v2: float with get, set
+    abstract v3: string with get, set
+    abstract v4: string with get, set
+    abstract v5: string with get, set
+
+type [<AllowNullLiteral>] F5_5Return =
+    abstract v1: float with get, set
+    abstract v2: string with get, set
+    abstract v3: string with get, set
+    abstract v4: float with get, set
+    abstract v5: string with get, set
+
+type [<AllowNullLiteral>] F2_5_3V2 =
+    abstract v1: float with get, set
+    abstract v2: string with get, set
+    abstract v3: string with get, set
+    abstract v4: float with get, set
+    abstract v5: string with get, set
+
+type [<AllowNullLiteral>] Ff2_2V1 =
+    abstract value: string with get, set
+    abstract f: (string -> string) with get, set
+    abstract v2: float with get, set
+    abstract v3: float with get, set
+    abstract v4: string with get, set
+    abstract v5: string with get, set
+
+type [<AllowNullLiteral>] Ff2_2Return =
+    abstract result: string with get, set
+    abstract f: (string -> float -> string) with get, set
+    abstract v2: float with get, set
+    abstract v3: float with get, set
+    abstract v4: string with get, set
+    abstract v5: string with get, set
+
+/// Type Alias -> interface, NOT anonymous record
+type [<AllowNullLiteral>] NoUnion =
+    abstract v1: string with get, set
+
+/// Anonymous Record
+type Union1 =
+    U2<string, {| v1: string |}>
+
+/// less than 5 members -> Anonymous Record
+type Union4 =
+    U2<string, {| v1: string; v2: float; v3: float; v4: string |}>
+
+/// more than 4 members -> Interface
+type Union5 =
+    U2<string, Union5Case2>
+
+type [<AllowNullLiteral>] Union5Case2 =
+    abstract v1: string with get, set
+    abstract v2: float with get, set
+    abstract v3: float with get, set
+    abstract v4: string with get, set
+    abstract v5: string with get, set
+
+/// <summary>
+/// Source: (React)[<see href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87]" />
+/// 
+/// Similar to <c>fragments/react/f1</c> (but not generic)
+/// </summary>
+type UnionBivarianceHack =
+    U2<string, (string option -> unit)>
+
+/// <summary>Source: (React)[<see href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87]" /></summary>
+type [<AllowNullLiteral>] RefCallback<'T> =
+    /// <summary>Source: (React)[<see href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87]" /></summary>
+    [<Emit "$0($1...)">] abstract Invoke: instance: 'T option -> unit
+
+type [<AllowNullLiteral>] I1 =
+    /// Anon Record
+    abstract l1: {| v1: string |} with get, set
+    /// Interface
+    abstract l5: C5 with get, set
+    /// Anon Record
+    abstract c1: {| v1: string |}
+    /// Interface
+    abstract c5: C5
+    /// Anon Record
+    abstract f1: v1: {| v1: string |} -> {| v1: string |}
+    /// Interface
+    abstract f5: v1: I1F5V1 -> I1F5Return
+
+type [<AllowNullLiteral>] I1F5V1 =
+    abstract v1: string with get, set
+    abstract v2: float with get, set
+    abstract v3: float with get, set
+    abstract v4: string with get, set
+    abstract v5: string with get, set
+
+type [<AllowNullLiteral>] I1F5Return =
+    abstract v1: string with get, set
+    abstract v2: float with get, set
+    abstract v3: float with get, set
+    abstract v4: string with get, set
+    abstract v5: string with get, set
+
+type [<AllowNullLiteral>] T1 =
+    /// Anon Record
+    abstract l1: {| v1: string |} with get, set
+    /// Interface
+    abstract l5: C5 with get, set
+    /// Anon Record
+    abstract c1: {| v1: string |}
+    /// Interface
+    abstract c5: C5
+    /// Anon Record
+    abstract f1: v1: {| v1: string |} -> {| v1: string |}
+    /// Interface
+    abstract f5: v1: C5 -> C5
+
+module N1 =
+
+    type [<AllowNullLiteral>] IExports =
+        /// Anon Record
+        abstract l1: {| v1: string |} with get, set
+        /// Interface
+        abstract l5: IExportsL5 with get, set
+        /// Anon Record
+        abstract c1: {| v1: string |}
+        /// Interface
+        abstract c5: IExportsL5
+        /// Anon Record
+        abstract f1: v1: {| v1: string |} -> {| v1: string |}
+        /// Interface
+        abstract f5: v1: F5V1 -> F5Return
+
+    type [<AllowNullLiteral>] F5V1 =
+        abstract v1: string with get, set
+        abstract v2: float with get, set
+        abstract v3: float with get, set
+        abstract v4: string with get, set
+        abstract v5: string with get, set
+
+    type [<AllowNullLiteral>] F5Return =
+        abstract v1: string with get, set
+        abstract v2: float with get, set
+        abstract v3: float with get, set
+        abstract v4: string with get, set
+        abstract v5: string with get, set
+
+    type [<AllowNullLiteral>] IExportsL5 =
+        abstract v1: string with get, set
+        abstract v2: float with get, set
+        abstract v3: float with get, set
+        abstract v4: string with get, set
+        abstract v5: string with get, set
+
+type [<AllowNullLiteral>] C1 =
+    /// Anon Record
+    abstract l1: {| v1: string |} with get, set
+    /// Interface
+    abstract l5: C5 with get, set
+    /// Anon Record
+    abstract c1: {| v1: string |}
+    /// Interface
+    abstract c5: C5
+    /// Anon Record
+    abstract f1: v1: {| v1: string |} -> {| v1: string |}
+    /// Interface
+    abstract f5: v1: C1F5V1 -> C1F5Return
+
+type [<AllowNullLiteral>] C1F5V1 =
+    abstract v1: string with get, set
+    abstract v2: float with get, set
+    abstract v3: float with get, set
+    abstract v4: string with get, set
+    abstract v5: string with get, set
+
+type [<AllowNullLiteral>] C1F5Return =
+    abstract v1: string with get, set
+    abstract v2: float with get, set
+    abstract v3: float with get, set
+    abstract v4: string with get, set
+    abstract v5: string with get, set
+
+type [<AllowNullLiteral>] C1Static =
+    [<EmitConstructor>] abstract Create: unit -> C1
+
+type [<AllowNullLiteral>] C5 =
+    abstract v1: string with get, set
+    abstract v2: float with get, set
+    abstract v3: float with get, set
+    abstract v4: string with get, set
+    abstract v5: string with get, set
+
+type [<AllowNullLiteral>] Cn2V2V2_2 =
+    abstract v2_2_1: string with get, set
+    abstract v2_2_2: float with get, set
+    abstract v2_2_3: string with get, set
+    abstract v2_2_4: string with get, set
+    abstract v2_2_5: float with get, set
+
+type [<AllowNullLiteral>] Cn2V3V3_3V3_3_2 =
+    abstract v3_3_2_1: string with get, set
+    abstract v3_3_2_2: float with get, set
+    abstract v3_3_2_3: string with get, set
+    abstract v3_3_2_4: float with get, set
+    abstract v3_3_2_5: string with get, set
+    abstract v3_3_2_6: string with get, set
+
+type [<AllowNullLiteral>] Cn2V3 =
+    abstract v3_1: string with get, set
+    abstract v3_2: float with get, set
+    abstract v3_3: {| v3_3_1: string; v3_3_2: Cn2V3V3_3V3_3_2; v3_3_3: string |} with get, set
+    abstract v3_4: string with get, set
+    abstract v3_5: float with get, set

--- a/test/fragments/custom/type-literal.expected.fs
+++ b/test/fragments/custom/type-literal.expected.fs
@@ -21,6 +21,12 @@ let [<Import("l5","type-literal")>] l5: C5 = jsNative
 let [<Import("cn1","type-literal")>] cn1: {| v1: string; v2: {| v2_1: string; v2_2: {| v2_2_1: string; v2_2_2: float; v2_2_3: string |}; v2_3: {| v2_3_1: string; v2_3_2: string |}; v2_4: string |}; v3: float |} = jsNative
 /// Nested Anon records & Interfaces
 let [<Import("cn2","type-literal")>] cn2: {| v1: string; v2: {| v2_1: string; v2_2: Cn2V2V2_2; v2_3: {| v2_3_1: string; v2_3_2: string |}; v2_4: string |}; v3: Cn2V3 |} = jsNative
+/// <summary>
+/// NOT a Anonymous Record, instead Union type (read as TypeLiteral)
+/// 
+/// source: <see href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ab5329620abcfa7ffc990d93d45165b8e51a55ca/types/mocha/index.d.ts#L165">Mocha</see>
+/// </summary>
+let [<Import("state","type-literal")>] state: State = jsNative
 
 type [<AllowNullLiteral>] IExports =
     /// neither interface nor anon record
@@ -44,6 +50,9 @@ type [<AllowNullLiteral>] IExports =
     /// Input: interface; Return: anon interface
     abstract ff2_2: v1: Ff2_2V1 -> Ff2_2Return
     abstract C1: C1Static
+    /// read as Type Literal 
+    /// BUT: Input & Output must be extracted into Union
+    abstract e1: v: IExportsE1 -> IExportsE12
 
 type [<AllowNullLiteral>] F5_5V =
     abstract v1: string with get, set
@@ -106,16 +115,16 @@ type [<AllowNullLiteral>] Union5Case2 =
     abstract v5: string with get, set
 
 /// <summary>
-/// Source: (React)[<see href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87]" />
+/// Source: <see href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87">React</see>
 /// 
 /// Similar to <c>fragments/react/f1</c> (but not generic)
 /// </summary>
 type UnionBivarianceHack =
     U2<string, (string option -> unit)>
 
-/// <summary>Source: (React)[<see href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87]" /></summary>
+/// <summary>Source: <see href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87">React</see></summary>
 type [<AllowNullLiteral>] RefCallback<'T> =
-    /// <summary>Source: (React)[<see href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87]" /></summary>
+    /// <summary>Source: <see href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87">React</see></summary>
     [<Emit "$0($1...)">] abstract Invoke: instance: 'T option -> unit
 
 type [<AllowNullLiteral>] I1 =
@@ -228,6 +237,12 @@ type [<AllowNullLiteral>] C1F5Return =
 type [<AllowNullLiteral>] C1Static =
     [<EmitConstructor>] abstract Create: unit -> C1
 
+/// read as Type Literal 
+/// BUT: must be printed as Union
+type [<StringEnum>] [<RequireQualifiedAccess>] E1 =
+    | [<CompiledName "Alpha">] Alpha
+    | [<CompiledName "Beta">] Beta
+
 type [<AllowNullLiteral>] C5 =
     abstract v1: string with get, set
     abstract v2: float with get, set
@@ -256,3 +271,15 @@ type [<AllowNullLiteral>] Cn2V3 =
     abstract v3_3: {| v3_3_1: string; v3_3_2: Cn2V3V3_3V3_3_2; v3_3_3: string |} with get, set
     abstract v3_4: string with get, set
     abstract v3_5: float with get, set
+
+type [<StringEnum>] [<RequireQualifiedAccess>] State =
+    | Failed
+    | Passed
+
+type [<StringEnum>] [<RequireQualifiedAccess>] IExportsE1 =
+    | [<CompiledName "Alpha">] Alpha
+    | [<CompiledName "Beta">] Beta
+
+type [<StringEnum>] [<RequireQualifiedAccess>] IExportsE12 =
+    | [<CompiledName "Gamma">] Gamma
+    | [<CompiledName "Delta">] Delta

--- a/test/fragments/monaco/variableInModule.fs
+++ b/test/fragments/monaco/variableInModule.fs
@@ -9,14 +9,10 @@ let [<ImportAll("variableInModule")>] monaco: Monaco.IExports = jsNative
 module Monaco =
 
     type [<AllowNullLiteral>] IExports =
-        abstract EditorType: IExportsEditorType with get, set
+        abstract EditorType: {| ICodeEditor: string; IDiffEditor: string |} with get, set
 
     type [<AllowNullLiteral>] IDisposable =
         abstract dispose: unit -> unit
 
     type [<AllowNullLiteral>] IEvent<'T> =
         [<Emit "$0($1...)">] abstract Invoke: listener: ('T -> obj option) * ?thisArg: obj -> IDisposable
-
-    type [<AllowNullLiteral>] IExportsEditorType =
-        abstract ICodeEditor: string with get, set
-        abstract IDiffEditor: string with get, set

--- a/test/fragments/react/f7.fs
+++ b/test/fragments/react/f7.fs
@@ -7,4 +7,4 @@ open Fable.Core.JS
 type SyntheticEvent = React.SyntheticEvent
 
 type [<AllowNullLiteral>] EventHandler<'E when 'E :> SyntheticEvent<obj option>> =
-    abstract bivarianceHack: ``event``: 'E -> unit
+    [<Emit "$0($1...)">] abstract Invoke: ``event``: 'E -> unit

--- a/test/fragments/regressions/#278-typeliterals-return.d.ts
+++ b/test/fragments/regressions/#278-typeliterals-return.d.ts
@@ -4,6 +4,9 @@ export module TypeLiteralsAsReturnValue {
     class Class {
         /**
          * This should generate two interfaces: 'Class' and 'ClassFooReturn'. The second should have a single property 'i'.
+         * 
+         * ^^^^^^
+         * That's old behaviour. Now: it generates Anonymous Record
          */
         Foo(): { i: number };
     }

--- a/test/fragments/regressions/#278-typeliterals-return.expected.fs
+++ b/test/fragments/regressions/#278-typeliterals-return.expected.fs
@@ -13,10 +13,10 @@ module TypeLiteralsAsReturnValue =
 
     type [<AllowNullLiteral>] Class =
         /// This should generate two interfaces: 'Class' and 'ClassFooReturn'. The second should have a single property 'i'.
-        abstract Foo: unit -> ClassFooReturn
-
-    type [<AllowNullLiteral>] ClassFooReturn =
-        abstract i: float with get, set
+        /// 
+        /// ^^^^^^
+        /// That's old behaviour. Now: it generates Anonymous Record
+        abstract Foo: unit -> {| i: float |}
 
     type [<AllowNullLiteral>] ClassStatic =
         [<EmitConstructor>] abstract Create: unit -> Class

--- a/test/fragments/regressions/#314-inline-destruct.expected.fs
+++ b/test/fragments/regressions/#314-inline-destruct.expected.fs
@@ -9,21 +9,9 @@ type [<AllowNullLiteral>] IExports =
     abstract DoubleKeyMap: DoubleKeyMapStatic
 
 type [<AllowNullLiteral>] DoubleKeyMap<'TKey1, 'TKey2, 'TValue> =
-    abstract set: p0: DoubleKeyMapSetP0 * value: 'TValue -> unit
-    abstract get: p0: DoubleKeyMapGetP0 -> 'TValue option
-    abstract delete: p0: DoubleKeyMapDeleteP0 -> unit
-
-type [<AllowNullLiteral>] DoubleKeyMapSetP0 =
-    abstract key1: 'TKey1 with get, set
-    abstract key2: 'TKey2 with get, set
-
-type [<AllowNullLiteral>] DoubleKeyMapGetP0 =
-    abstract key1: 'TKey1 with get, set
-    abstract key2: 'TKey2 with get, set
-
-type [<AllowNullLiteral>] DoubleKeyMapDeleteP0 =
-    abstract key1: 'TKey1 with get, set
-    abstract key2: 'TKey2 with get, set
+    abstract set: p0: {| key1: 'TKey1; key2: 'TKey2 |} * value: 'TValue -> unit
+    abstract get: p0: {| key1: 'TKey1; key2: 'TKey2 |} -> 'TValue option
+    abstract delete: p0: {| key1: 'TKey1; key2: 'TKey2 |} -> unit
 
 type [<AllowNullLiteral>] DoubleKeyMapStatic =
     [<EmitConstructor>] abstract Create: unit -> DoubleKeyMap<'TKey1, 'TKey2, 'TValue>

--- a/test/fragments/regressions/#400-type-literal-in-union-type.d.ts
+++ b/test/fragments/regressions/#400-type-literal-in-union-type.d.ts
@@ -38,8 +38,20 @@ export type Union2Union5 = string | { v1: string, v2: { v1: string, v2: number, 
 export type Union0 = string | {}
 
 /** 
- * Source: (React)[https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87]
+ * Source: [React](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87)
  * 
  * Similar to `fragments/react/f1` (but not generic) 
  */
 export type UnionBivarianceHack = string | { bivarianceHack(instance: string | null): void }["bivarianceHack"]
+
+/**
+ * Anon Record (-> everything immutable) 
+ * name: readonly, age: mutable 
+ */
+export type UnionReadonly2 = string | { readonly name: string, age: number }
+/**
+ * Interface
+ * name: readonly, age: mutable 
+ * (v3 mutable, v4 readonly, v5 mutable)
+ */
+export type UnionReadonly5 = string | { readonly name: string, age: number, v3: string, v4: string, v5: number }

--- a/test/fragments/regressions/#400-type-literal-in-union-type.d.ts
+++ b/test/fragments/regressions/#400-type-literal-in-union-type.d.ts
@@ -1,0 +1,45 @@
+/** simple Union without anything special */
+export type Union = string | number
+/** Type Alias -> interface, NOT anonymous record */
+export type NoUnion = { v1: string }
+/** Anonymous Record */
+export type Union1 = string | { v1: string }
+/** Anonymous Record */
+export type Union2 = string | { v1: string, v2: number }
+/** Anonymous Record */
+export type Union3 = string | { v1: string, v2: number, v3: number}
+/** Anonymous Record */
+export type Union4 = string | { v1: string, v2: number, v3: number, v4: string }
+/** Interface */
+export type Union5 = string | { v1: string, v2: number, v3: number, v4: string, v5: string }
+
+/** 2 Interfaces */
+export type Union5_6 = { v1: string, v2: number, v3: number, v4: string, v5: string } | { v1: number, v2: number, v3: number, v4: number, v5: number, v6: string }
+
+/** 3 Anonymous Records */
+export type Union1_2_4 = {v1: string} | { v1: number, v2: string } | { v1: string, v2: number, v3: number, v4: string }
+
+/** 2 Anonymous Records, 1 Interface */
+export type Union1_5_3 = {v1: string} | { v1: string, v2: number, v3: number, v4: string, v5: string } | { v1: string, v2: number, v3: number}
+
+/** Anonymous Records, v2 & v3 optional */
+export type UnionOptional3 = string | { v1: string, v2?: number, v3?: number}
+/** Interface, v2 & v3 optional */
+export type UnionOptional5 = string | { v1: string, v2?: number, v3?: number, v4: string, v5: string }
+
+/** Anonymous Records in Anonymous Record */
+export type Union1Union1 = string | { v1: { nested1: string }}
+/** Anonymous Record in Interface */
+export type Union5Union1 = string | { v1: string, v2: number, v3: { nested1: string, nested2: number }, v4: string, v5: string }
+/** Interface in Anonymous Record */
+export type Union2Union5 = string | { v1: string, v2: { v1: string, v2: number, v3: number, v4: string, v5: string }}
+
+/** Empty interface */
+export type Union0 = string | {}
+
+/** 
+ * Source: (React)[https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87]
+ * 
+ * Similar to `fragments/react/f1` (but not generic) 
+ */
+export type UnionBivarianceHack = string | { bivarianceHack(instance: string | null): void }["bivarianceHack"]

--- a/test/fragments/regressions/#400-type-literal-in-union-type.expected.fs
+++ b/test/fragments/regressions/#400-type-literal-in-union-type.expected.fs
@@ -1,0 +1,131 @@
+// ts2fable 0.0.0
+module rec ``#400-type-literal-in-union-type``
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+/// simple Union without anything special
+type Union =
+    U2<string, float>
+
+/// Type Alias -> interface, NOT anonymous record
+type [<AllowNullLiteral>] NoUnion =
+    abstract v1: string with get, set
+
+/// Anonymous Record
+type Union1 =
+    U2<string, {| v1: string |}>
+
+/// Anonymous Record
+type Union2 =
+    U2<string, {| v1: string; v2: float |}>
+
+/// Anonymous Record
+type Union3 =
+    U2<string, {| v1: string; v2: float; v3: float |}>
+
+/// Anonymous Record
+type Union4 =
+    U2<string, {| v1: string; v2: float; v3: float; v4: string |}>
+
+/// Interface
+type Union5 =
+    U2<string, Union5Case2>
+
+type [<AllowNullLiteral>] Union5Case2 =
+    abstract v1: string with get, set
+    abstract v2: float with get, set
+    abstract v3: float with get, set
+    abstract v4: string with get, set
+    abstract v5: string with get, set
+
+/// 2 Interfaces
+type Union5_6 =
+    U2<Union5_6Case1, Union5_6Case2>
+
+type [<AllowNullLiteral>] Union5_6Case1 =
+    abstract v1: string with get, set
+    abstract v2: float with get, set
+    abstract v3: float with get, set
+    abstract v4: string with get, set
+    abstract v5: string with get, set
+
+type [<AllowNullLiteral>] Union5_6Case2 =
+    abstract v1: float with get, set
+    abstract v2: float with get, set
+    abstract v3: float with get, set
+    abstract v4: float with get, set
+    abstract v5: float with get, set
+    abstract v6: string with get, set
+
+/// 3 Anonymous Records
+type Union1_2_4 =
+    U3<{| v1: string |}, {| v1: float; v2: string |}, {| v1: string; v2: float; v3: float; v4: string |}>
+
+/// 2 Anonymous Records, 1 Interface
+type Union1_5_3 =
+    U3<{| v1: string |}, Union1_5_3Case2, {| v1: string; v2: float; v3: float |}>
+
+type [<AllowNullLiteral>] Union1_5_3Case2 =
+    abstract v1: string with get, set
+    abstract v2: float with get, set
+    abstract v3: float with get, set
+    abstract v4: string with get, set
+    abstract v5: string with get, set
+
+/// Anonymous Records, v2 & v3 optional
+type UnionOptional3 =
+    U2<string, {| v1: string; v2: float option; v3: float option |}>
+
+/// Interface, v2 & v3 optional
+type UnionOptional5 =
+    U2<string, UnionOptional5Case2>
+
+type [<AllowNullLiteral>] UnionOptional5Case2 =
+    abstract v1: string with get, set
+    abstract v2: float option with get, set
+    abstract v3: float option with get, set
+    abstract v4: string with get, set
+    abstract v5: string with get, set
+
+/// Anonymous Records in Anonymous Record
+type Union1Union1 =
+    U2<string, {| v1: {| nested1: string |} |}>
+
+/// Anonymous Record in Interface
+type Union5Union1 =
+    U2<string, Union5Union1Case2>
+
+type [<AllowNullLiteral>] Union5Union1Case2 =
+    abstract v1: string with get, set
+    abstract v2: float with get, set
+    abstract v3: {| nested1: string; nested2: float |} with get, set
+    abstract v4: string with get, set
+    abstract v5: string with get, set
+
+/// Interface in Anonymous Record
+type Union2Union5 =
+    U2<string, {| v1: string; v2: Union2Union5V2 |}>
+
+/// Empty interface
+type Union0 =
+    U2<string, Union0Case2>
+
+type [<AllowNullLiteral>] Union0Case2 =
+    interface end
+
+/// <summary>
+/// Source: (React)[<see href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87]" />
+/// 
+/// Similar to <c>fragments/react/f1</c> (but not generic)
+/// </summary>
+type UnionBivarianceHack =
+    U2<string, (string option -> unit)>
+
+type [<AllowNullLiteral>] Union2Union5V2 =
+    abstract v1: string with get, set
+    abstract v2: float with get, set
+    abstract v3: float with get, set
+    abstract v4: string with get, set
+    abstract v5: string with get, set

--- a/test/fragments/regressions/#400-type-literal-in-union-type.expected.fs
+++ b/test/fragments/regressions/#400-type-literal-in-union-type.expected.fs
@@ -116,12 +116,30 @@ type [<AllowNullLiteral>] Union0Case2 =
     interface end
 
 /// <summary>
-/// Source: (React)[<see href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87]" />
+/// Source: <see href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87">React</see>
 /// 
 /// Similar to <c>fragments/react/f1</c> (but not generic)
 /// </summary>
 type UnionBivarianceHack =
     U2<string, (string option -> unit)>
+
+/// Anon Record (-> everything immutable) 
+/// name: readonly, age: mutable
+type UnionReadonly2 =
+    U2<string, {| name: string; age: float |}>
+
+/// Interface
+/// name: readonly, age: mutable 
+/// (v3 mutable, v4 readonly, v5 mutable)
+type UnionReadonly5 =
+    U2<string, UnionReadonly5Case2>
+
+type [<AllowNullLiteral>] UnionReadonly5Case2 =
+    abstract name: string
+    abstract age: float with get, set
+    abstract v3: string with get, set
+    abstract v4: string with get, set
+    abstract v5: float with get, set
 
 type [<AllowNullLiteral>] Union2Union5V2 =
     abstract v1: string with get, set

--- a/test/fragments/regressions/#400-type-literal-in-union-type.expected.fs
+++ b/test/fragments/regressions/#400-type-literal-in-union-type.expected.fs
@@ -1,5 +1,8 @@
 // ts2fable 0.0.0
 module rec ``#400-type-literal-in-union-type``
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#428-noresizearray.expected.fs
+++ b/test/fragments/regressions/#428-noresizearray.expected.fs
@@ -9,10 +9,7 @@ type [<AllowNullLiteral>] IExports =
     abstract Appwrite: AppwriteStatic
 
 type [<AllowNullLiteral>] Appwrite =
-    abstract account: AppwriteAccount with get, set
+    abstract account: {| createDocument: string[] |} with get, set
 
 type [<AllowNullLiteral>] AppwriteStatic =
     [<EmitConstructor>] abstract Create: unit -> Appwrite
-
-type [<AllowNullLiteral>] AppwriteAccount =
-    abstract createDocument: string[] with get, set

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -560,6 +560,13 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
             // -> emit `#nowarn` for `@deprecated` instead of just usage
             testNowarn "deprecated-usage" true
 
+    // https://github.com/fable-compiler/ts2fable/issues/400
+    it "type-literal" <| fun _ ->
+        let tsPaths = ["test/fragments/custom/type-literal.d.ts"]
+        let fsPath = "test/fragments/custom/type-literal.fs"
+        let expected = "test/fragments/custom/type-literal.expected.fs"
+        convertAndCompareAgainstExpected tsPaths fsPath expected
+
     // https://github.com/fable-compiler/ts2fable/pull/275
     it "regression #275 remove private members" <| fun _ ->
         runRegressionTest "#275-private-members"
@@ -650,6 +657,10 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
     // https://github.com/fable-compiler/ts2fable/issues/393
     it "regression #393 Mutable Variables become immutable" <| fun _ ->
         runRegressionTest "#393-mutable-variables-become-immutable"
+
+    // https://github.com/fable-compiler/ts2fable/issues/400
+    it "regression #400 Type Literal in Union Type" <| fun _ ->
+        runRegressionTest "#400-type-literal-in-union-type"
 
     // https://github.com/fable-compiler/ts2fable/issues/401
     it "regression #401 Variable with generic type parameter" <| fun _ ->

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -561,7 +561,7 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
             testNowarn "deprecated-usage" true
 
     // https://github.com/fable-compiler/ts2fable/issues/400
-    it "type-literal" <| fun _ ->
+    it "type literal" <| fun _ ->
         let tsPaths = ["test/fragments/custom/type-literal.d.ts"]
         let fsPath = "test/fragments/custom/type-literal.fs"
         let expected = "test/fragments/custom/type-literal.expected.fs"

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -566,6 +566,13 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
         let fsPath = "test/fragments/custom/type-literal.fs"
         let expected = "test/fragments/custom/type-literal.expected.fs"
         convertAndCompareAgainstExpected tsPaths fsPath expected
+    // https://github.com/fable-compiler/ts2fable/issues/415
+    it "type literal indexer" <| fun _ ->
+        let tsPaths = ["test/fragments/custom/type-literal-indexer.d.ts"]
+        let fsPath = "test/fragments/custom/type-literal-indexer.fs"
+        let expected = "test/fragments/custom/type-literal-indexer.expected.fs"
+        convertAndCompareAgainstExpected tsPaths fsPath expected
+
 
     // https://github.com/fable-compiler/ts2fable/pull/275
     it "regression #275 remove private members" <| fun _ ->

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -292,7 +292,7 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
             fsFiles
             |>  (
                     existOnlyOneByName "EventHandler" FsType.isInterface
-                    <&&> existOnlyOneByName "bivarianceHack" FsType.isFunction
+                    <&&> existOnlyOneByName "Invoke" FsType.isFunction
                 )
             |> equal true
 


### PR DESCRIPTION
Convert Anonymous JS Object Types into F# Anonymous Records (as discussed in comments of #400).  
That's only done when object has `<= 4` members. Otherwise it's still extracted into an Interface:
```typescript
export const c1: { v1: string }
export const c5: { v1: string, v2: number, v3: number, v4: string, v5: string }
```
==>
```fsharp
let [<Import(...)>] c1: {| v1: string |} = jsNative
let [<Import(...)>] c5: C5 = jsNative
type [<AllowNullLiteral>] C5 =
    abstract v1: string with get, set
    // ...
```

`3` or `4` seems like a reasonable split. I decided for `4`.

There's an important difference between Anon Record & Interface: Properties in Anon Record are always immutable, while in Interface they are mutable unless the field is marked as readonly (`{ readonly value: string }`).


Currently all Anonymous Object types in TS with `<= 4` members are translated into Anon Records. I'm not sure that's the best solution. It might be reasonable to use Anon Records only in locations when it has to be created in F#, but not when returned from JS. That means:
* Anon Records: function parameter, Case in Union, mutable variables (`let`, `var`)
* Interface: function return value, constant value

```typescript
export function f( v: { v1: string, v2: number } ): { v1: number, v2: string, v3: string }
```
```fsharp
abstract f: v: {| v1: string; v2: float; v3: string |} -> FReturn
```

Input: written in F# -> should be easy to do in F#. Anon Record is fast to write, especially easier than an Interface with mutable properties.
Output: consumed in F# -> not important how easy it is to create, but correctness -- and probably how easy it is to pass to other functions. Interface can be mutable like original in JS. And specifying type is easy via name (vs. long thingy for Anon Records).

Maybe just go half way: lower member limit for interfaces in such cases? Like:
* Input: keep `<= 4 ` -> Anon record, `> 4`: Interface 
* Output: reduce to `<= 2` -> Anon record, `> 2`: Interface



-------------------------------

Fixes #400: Type Literal in Union Type.   
Like above: small types get translated into Anon Record, bigger types into Interfaces. Naming: `{UnionName}Case{i}`:
```typescript
export type Union1 = string | { v1: string }
export type Union5 = string | { v1: string, v2: number, v3: number, v4: string, v5: string }
```
==>
```fsharp
type Union1 = U2<string, {| v1: string |}>
type Union5 = U2<string, Union5Case2>
type [<AllowNullLiteral>] Union5Case2 =
    abstract v1: string with get, set
    // ...
```