### PR TITLE
Fix #403: Unescaped Chars in XML Comments

### DIFF
--- a/src/print.fs
+++ b/src/print.fs
@@ -233,24 +233,10 @@ let printComments (lines: ResizeArray<string>) (indent: string) (comments: FsCom
             sprintf "<%s>" nameWithAttributes |> printLine
             content |> printLines
             sprintf "</%s>" name |> printLine
-    
-    let containsXml (text: string) =
-        //cannot test for just < or > -> might not be xml tags like `the return value should be Option<string>`
-        // -> look for valid_ish xml doc tags
-        [
-            "<para>"
-            "<code>"
-            "<c>"
-            "<paramref name="
-            "<typeparamref name="
-            "<see href="
-            "<see cref="
-        ]
-        |> List.exists text.Contains
 
     match comments with
     | [] -> ()
-    | [ FsComment.Summary lines ] when lines |> List.forall (not << containsXml) ->
+    | [ FsComment.Summary lines ] when lines |> List.forall (not << FsComment.containsXml) ->
         // only summary
         // -> no `<summary>` tag necessary
         // BUT: without `<summary>` `<` and `>` are automatically escaped  (https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/xml-documentation#comments-without-xml-tags)

--- a/src/syntax.fs
+++ b/src/syntax.fs
@@ -122,6 +122,21 @@ module FsComment =
     let isSummary v = match v with | FsComment.Summary _ -> true | _ -> false
     let asSummary v = match v with | FsComment.Summary o -> Some o | _ -> None
 
+    /// Checks if passed xml comment text contains xml comment tags
+    let containsXml (text: string) =
+        //cannot test for just < or > -> might not be xml tags like `the return value should be Option<string>`
+        // -> look for valid_ish xml doc tags
+        [
+            "<para>"
+            "<code>"
+            "<c>"
+            "<paramref name="
+            "<typeparamref name="
+            "<see href="
+            "<see cref="
+        ]
+        |> List.exists text.Contains
+
 type FsParam =
     {
         Name: string

--- a/test/fragments/custom/comments/transformToXml.expected.fs
+++ b/test/fragments/custom/comments/transformToXml.expected.fs
@@ -78,7 +78,7 @@ type [<AllowNullLiteral>] AllTextTransformations =
 type [<AllowNullLiteral>] AllTags =
     interface end
 
-/// <summary>Testing <c>@see</c> tag (-> <c><seealso...</c>)</summary>
+/// <summary>Testing <c>@see</c> tag (-> <c>&lt;seealso...</c>)</summary>
 /// <seealso cref="SomeType1">should be cref</seealso>
 /// <seealso cref="Module.SomeType2">should be cref</seealso>
 /// <seealso href="https://github.com/fable-compiler/ts2fable">should be href</seealso>
@@ -113,7 +113,7 @@ type [<AllowNullLiteral>] SeeTag =
 type [<AllowNullLiteral>] Separator =
     interface end
 
-/// <summary>Exception Type in <c>@throws</c> is optional, but required in <c><exception></c></summary>
+/// <summary>Exception Type in <c>@throws</c> is optional, but required in <c>&lt;exception></c></summary>
 /// <exception cref="SomeException"> exception with type</exception>
 /// <exception cref="Module.SomeException"> exception with type in module</exception>
 /// <exception cref="">exception without type</exception>

--- a/test/fragments/regressions/#403-xml-comment-escape-chars.d.ts
+++ b/test/fragments/regressions/#403-xml-comment-escape-chars.d.ts
@@ -1,0 +1,29 @@
+/**
+ * Chars to escape: & <
+ * Chars that might be reasonable to escape, but not needed: > ' "
+ * 
+ * In code environment: <c> & < > ' " </c>
+ * 
+ * In link: [search fsharp & ts2fable](https://duckduckgo.com/?q=fsharp+ts2fable&ia=web)
+ */
+export interface I { }
+/**
+ * No escape here: just summary, no xml tags
+ * 
+ * Chars: & < > ' "
+ */
+export interface I2 { }
+/**
+ * Escape chars here: some extra tag
+ * 
+ * @remarks Remarks: Stuff & Stuff: & < > ' "
+ */
+export interface I3 { }
+/**
+ * No escape in deprecated: gets extracted into obsolete attribute
+ * 
+ * With one Exception: double-quotation marks must be escaped!
+ * 
+ * @deprecated Ok: &; not "ok"!
+ */
+export interface I4 { }

--- a/test/fragments/regressions/#403-xml-comment-escape-chars.expected.fs
+++ b/test/fragments/regressions/#403-xml-comment-escape-chars.expected.fs
@@ -1,0 +1,35 @@
+// ts2fable 0.0.0
+module rec ``#403-xml-comment-escape-chars``
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+/// <summary>
+/// Chars to escape: &amp; &lt;
+/// Chars that might be reasonable to escape, but not needed: > ' "
+/// 
+/// In code environment: &lt;c> &amp; &lt; > ' " &lt;/c>
+/// 
+/// In link: <see href="https://duckduckgo.com/?q=fsharp+ts2fable&amp;ia=web">search fsharp &amp; ts2fable</see>
+/// </summary>
+type [<AllowNullLiteral>] I =
+    interface end
+
+/// No escape here: just summary, no xml tags
+/// 
+/// Chars: & < > ' "
+type [<AllowNullLiteral>] I2 =
+    interface end
+
+/// <summary>Escape chars here: some extra tag</summary>
+/// <remarks>Remarks: Stuff &amp; Stuff: &amp; &lt; > ' "</remarks>
+type [<AllowNullLiteral>] I3 =
+    interface end
+
+/// No escape in deprecated: gets extracted into obsolete attribute
+/// 
+/// With one Exception: double-quotation marks must be escaped!
+[<Obsolete("Ok: &; not \"ok\"!")>]
+type [<AllowNullLiteral>] I4 =
+    interface end

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -528,4 +528,8 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
     it "regression #393 Mutable Variables become immutable" <| fun _ ->
         runRegressionTest "#393-mutable-variables-become-immutable"
 
+    // https://github.com/fable-compiler/ts2fable/issues/400
+    it "regression #403 Invalid Xml Comments because of unescaped chars" <| fun _ ->
+        runRegressionTest "#403-xml-comment-escape-chars"
+
 )?timeout(15_000)


### PR DESCRIPTION
Note: only `&` and `<` get escaped, NOT `>'"`. These are not necessary
for F# compiler.
But results in some strange constructs like `&lt;exception>` -> Start is
escaped, But end isn't.