### PR TITLE
Partial Fix of #401: Variables & Properties with generic type parameter

### DIFF
--- a/src/print.fs
+++ b/src/print.fs
@@ -26,8 +26,9 @@ let printType (tp: FsType): string =
         tp.Types |> List.map printType |> String.concat " * " |> line.Add
         line |> String.concat ""
     | FsType.Variable vb ->
-        //todo: remove -> into catchall instead
-        failwithf "there shouldn't be a FsVariable any more. %A" vb
+        printfn "Variable in printType that should have been converted into property: %s" (vb.Name)
+        let vtp = vb.Type |> printType
+        sprintf "abstract %s: %s%s" vb.Name vtp (if vb.IsConst then "" else " with get, set")
     | FsType.StringLiteral _ -> "string"
     | FsType.Property p -> printType p.Type
     | FsType.Enum en ->

--- a/src/print.fs
+++ b/src/print.fs
@@ -19,23 +19,15 @@ let printType (tp: FsType): string =
     | FsType.Generic g ->
         printGeneric g
     | FsType.Function ft ->
-        let line = ResizeArray()
-        let typs =
-            if ft.Params.Length = 0 then
-                [ simpleType "unit"; ft.ReturnType ]
-            else
-                (ft.Params |> List.map (fun p -> p.Type)) @ [ ft.ReturnType ]
-        "(" |> line.Add
-        typs |> List.map printType |> String.concat " -> " |> line.Add
-        ")"|> line.Add
-        line |> String.concat ""
+        printFunctionType ft
+        |> sprintf "(%s)"
     | FsType.Tuple tp ->
         let line = ResizeArray()
         tp.Types |> List.map printType |> String.concat " * " |> line.Add
         line |> String.concat ""
     | FsType.Variable vb ->
-        let vtp = vb.Type |> printType
-        sprintf "abstract %s: %s%s" vb.Name vtp (if vb.IsConst then "" else " with get, set")
+        //todo: remove -> into catchall instead
+        failwithf "there shouldn't be a FsVariable any more. %A" vb
     | FsType.StringLiteral _ -> "string"
     | FsType.Property p -> printType p.Type
     | FsType.Enum en ->
@@ -64,6 +56,36 @@ let printType (tp: FsType): string =
     | _ ->
         printfn "unsupported printType %s: %s" (getTypeName tp) (getName tp)
         "obj"
+
+/// unlike `printType`, don't surround Function with brackets:
+/// * `printType`: `(string -> string)`
+/// * `printRootType`: `string -> string`
+/// Necessary for generic properties `'T -> 'T`: not valid in brackets
+let printRootType (tp: FsType): string =
+    match tp with
+    | FsType.Function f -> printFunctionType f
+    | _ -> printType tp
+
+let printFunctionType (f: FsFunction) =
+    match f.Params with
+    | [] -> sprintf "unit -> %s" (printType f.ReturnType)
+    | ps ->
+        let ps =
+            ps
+            |> List.map (fun p ->
+                let t = printType p.Type
+                if p.Optional then
+                    // this bracket isn't always necessary for example:
+                    // `const f: (value?: string) => void`
+                    // in F#: `abstract f: (string) option -> unit`
+                    // but it's easier to always put into brackets, than to discrimate 
+                    // when it's needed (tuple, function) and when not (simple type).
+                    sprintf "(%s) option" t
+                else
+                    t
+            )
+        ps @ [ printType f.ReturnType ]
+        |> String.concat " -> "
 
 let printGeneric (g: FsGenericType): string =
     let line = ResizeArray()
@@ -124,7 +146,7 @@ let printFunction (fn: FsFunction): string =
     line |> String.concat ""
 
 let printProperty (pr: FsProperty): string =
-    sprintf "%sabstract %s: %s%s%s%s"
+    sprintf "%sabstract %s: %s%s%s%s%s"
         (   match pr.Kind with
             | FsPropertyKind.Regular -> ""
             | FsPropertyKind.Index -> "[<EmitIndexer>] "
@@ -135,14 +157,37 @@ let printProperty (pr: FsProperty): string =
             | Some idx -> sprintf "%s: %s -> " idx.Name (printType idx.Type)
         )
         (
-            let t = printType pr.Type
-            // if `Option<A * B>`, surround tuple with brackets (`(A * B) option`), otherwise it's emitted as `A * Option<B>` (`A * B option`)
-            match pr.Option, pr.Type |> FsType.asTuple with
-            | true, (Some { Kind = FsTupleKind.Tuple; Types = tys }) when (tys |> List.length) > 1 ->
-                sprintf "(%s)" t
-            | _ -> t
+            let t = printRootType pr.Type
+            let optionInBrackets ty =
+                if pr.Option then
+                    match ty with
+                    // if `Option<A * B>`, surround tuple with brackets (`(A * B) option`), otherwise it's emitted as `A * Option<B>` (`A * B option`)
+                    | FsType.Tuple { Kind = FsTupleKind.Tuple; Types = tys } when (tys |> List.length) > 1 ->
+                        sprintf "(%s)" t
+                    // brackets required for function type like `(string -> string) option`
+                    | FsType.Function _ ->
+                        sprintf "(%s)" t
+                    | _ -> t
+                else
+                    t
+
+            match pr.Accessor with
+            | ReadOnly -> 
+                optionInBrackets pr.Type
+            | WriteOnly | ReadWrite ->
+                match pr.Type with
+                | FsType.Function _ -> 
+                    sprintf "(%s)" t
+                | _ -> optionInBrackets pr.Type
         )
         (if pr.Option then " option" else "")
+        (
+            // generic type parameter
+            match pr.Type with
+            | FsType.Function f when f.TypeParameters.Length > 0 ->
+                printGenericTypeConstraints f.TypeParameters
+            | _ -> ""
+        )
         (
             match pr.Accessor with
             | ReadOnly -> ""

--- a/test/fragments/regressions/#401-variable-generic.d.ts
+++ b/test/fragments/regressions/#401-variable-generic.d.ts
@@ -40,6 +40,11 @@ export namespace N {
     /** get, set */
     let f12: <T>(v1: T, v2: T) => T;
 
+    /** get */
+    const f13: (v1: string, v2: string) => string;
+    /** get, set */
+    let f14: (v1: string, v2: string) => string;
+
     /** 
      * get 
      * 
@@ -165,6 +170,12 @@ export interface I {
     /** get, set */
     f12: <T>(v1: T, v2: T) => T;
 
+    /** get */
+    readonly f13: (v1: string, v2: string) => string;
+    /** get, set */
+    f14: (v1: string, v2: string) => string;
+
+
     /** 
      * get 
      * 
@@ -248,6 +259,58 @@ export interface I {
      */
     o4: <T>(v1: T, v2?: [T, T]) => T;
 
+    /**
+     * get
+     * 
+     * optional
+     */
+    readonly opt1?: string;
+    /**
+     * get, set
+     * 
+     * optional
+     */
+    opt2?: string;
+    // // F#: `abstract opt2: ('T -> 'T) option`
+    // // -> The type parameter 'T is not defined.
+    // // Note: same `with get, set` is allowed (but neither `with get` nor `with set`)
+    // /**
+    //  * get
+    //  * 
+    //  * optional
+    //  */
+    // readonly opt3?: <T>(v1: T) => T;
+    /**
+     * get, set
+     * 
+     * optional
+     */
+    opt4?: <T>(v1: T) => T;
+    /**
+     * get
+     * 
+     * optional
+     */
+    readonly opt5?: (v1: string, v2: string) => string;
+    // /**
+    //  * get
+    //  * 
+    //  * optional
+    //  */
+    // readonly opt6?: <T>(v1: T, v2: T) => T;
+    /**
+     * get, set
+     * 
+     * optional
+     */
+    opt7?: (v1: string, v2: string) => string;
+    /**
+     * get, set
+     * 
+     * optional
+     */
+    opt8?: <T>(v1: T, v2: T) => T;
+
     /** function */
     ff1<T>(f: ((value: T) => T)): ((value: T) => T);
     /** function */
@@ -289,6 +352,11 @@ export class C {
     readonly f11: <T>(v1: T, v2: T) => T;
     /** get, set */
     f12: <T>(v1: T, v2: T) => T;
+
+    /** get */
+    readonly f13: (v1: string, v2: string) => string;
+    /** get, set */
+    f14: (v1: string, v2: string) => string;
 
     /** 
      * get 

--- a/test/fragments/regressions/#401-variable-generic.d.ts
+++ b/test/fragments/regressions/#401-variable-generic.d.ts
@@ -255,3 +255,128 @@ export interface I {
     /** function */
     ff3<T>(v1: T, v2: T | string): T | number
 }
+
+export class C {
+       /** get */
+    readonly v1: string;
+
+    /** get */
+    readonly f1: (value: string) => number;
+
+    /** get */
+    readonly f2: <T>(value: T) => number;
+    /** get */
+    readonly f3: <T>(value: string) => T;
+    /** get */
+    readonly f4: <T>(value: T) => T;
+
+    /** get, set */
+    f5: <T>(value: T) => T;
+    /** get, set */
+    f6: <T>(value: T) => T;
+
+    /** get */
+    readonly f7: <T>(v1: T, v2: T) => T;
+    /** get */
+    readonly f8: <T>(v1: T | string, v2: string | number | T) => T;
+
+    /** get */
+    readonly f9: <T>(f1: ((v1: T, v2: T) => T), f2: ((v1: string | T, v2: T | number) => string | T)) => T | string
+    /** get, set */
+    f10: <T>(f1: ((v1: T, v2: T) => T), f2: ((v1: string | T, v2: T | number) => string | T)) => T | string
+
+    /** get */
+    readonly f11: <T>(v1: T, v2: T) => T;
+    /** get, set */
+    f12: <T>(v1: T, v2: T) => T;
+
+    /** 
+     * get 
+     * 
+     * T extends A
+     */
+    readonly gf1: <T extends A>(value: T) => T
+    /** 
+     * get, set
+     * 
+     * T extends A
+     */
+    gf2: <T extends A>(value: T) => T
+    /** 
+     * get 
+     * 
+     * T extends A
+     */
+    readonly gf3: <T extends A>(v1: T, v2: T) => T
+    /** 
+     * get, set
+     * 
+     * T extends A
+     */
+    gf4: <T extends A>(v1: T, v2: T) => T
+    /**
+     * get
+     * 
+     * T extends A
+     * U extends A & B
+     */
+    readonly gf5: <T extends A, U extends A & B>(v1: T, v2: U) => U
+    /**
+     * get, set
+     * 
+     * T extends A
+     * U extends A & B
+     */
+    gf6: <T extends A, U extends A & B>(v1: T, v2: U) => U
+
+    /** get */
+    readonly arrayify: <T>(obj: T | T[]) => T[];
+    
+    /** get */
+    readonly izi1: (v1: string, v2: string) => void;
+    /** get, set */
+    izi3: (v1: string, v2: string) => void;
+    /** get */
+    readonly izi4: <T>(v1: T, v2: T) => T;
+    /** get, set */
+    izi5: <T>(v1: T, v2: T) => T;
+
+    /** get */
+    readonly t1: [string, string];
+    /** get */
+    readonly ft1: <T>(vs: [T, T]) => T;
+    /** get, set */
+    ft2: <T>(vs: [T, T]) => T;
+
+    /** 
+     * get
+     * 
+     * v2 optional
+     */
+    readonly o1: <T>(v1: T, v2?: T) => T;
+    /** 
+     * get, set
+     * 
+     * v2 optional
+     */
+    o2: <T>(v1: T, v2?: T) => T;
+    /** 
+     * get
+     * 
+     * v2 optional
+     */
+    readonly o3: <T>(v1: T, v2?: [T, T]) => T;
+    /** 
+     * get, set
+     * 
+     * v2 optional
+     */
+    o4: <T>(v1: T, v2?: [T, T]) => T;
+
+    /** function */
+    ff1<T>(f: ((value: T) => T)): ((value: T) => T);
+    /** function */
+    ff2<T>(f: ((value: T) => T), v: T): string;
+    /** function */
+    ff3<T>(v1: T, v2: T | string): T | number 
+}

--- a/test/fragments/regressions/#401-variable-generic.d.ts
+++ b/test/fragments/regressions/#401-variable-generic.d.ts
@@ -130,3 +130,128 @@ export namespace N {
     /** function */
     function ff3<T>(v1: T, v2: T | string): T | number
 }
+
+export interface I {
+    /** get */
+    readonly v1: string;
+
+    /** get */
+    readonly f1: (value: string) => number;
+
+    /** get */
+    readonly f2: <T>(value: T) => number;
+    /** get */
+    readonly f3: <T>(value: string) => T;
+    /** get */
+    readonly f4: <T>(value: T) => T;
+
+    /** get, set */
+    f5: <T>(value: T) => T;
+    /** get, set */
+    f6: <T>(value: T) => T;
+
+    /** get */
+    readonly f7: <T>(v1: T, v2: T) => T;
+    /** get */
+    readonly f8: <T>(v1: T | string, v2: string | number | T) => T;
+
+    /** get */
+    readonly f9: <T>(f1: ((v1: T, v2: T) => T), f2: ((v1: string | T, v2: T | number) => string | T)) => T | string
+    /** get, set */
+    f10: <T>(f1: ((v1: T, v2: T) => T), f2: ((v1: string | T, v2: T | number) => string | T)) => T | string
+
+    /** get */
+    readonly f11: <T>(v1: T, v2: T) => T;
+    /** get, set */
+    f12: <T>(v1: T, v2: T) => T;
+
+    /** 
+     * get 
+     * 
+     * T extends A
+     */
+    readonly gf1: <T extends A>(value: T) => T
+    /** 
+     * get, set
+     * 
+     * T extends A
+     */
+    gf2: <T extends A>(value: T) => T
+    /** 
+     * get 
+     * 
+     * T extends A
+     */
+    readonly gf3: <T extends A>(v1: T, v2: T) => T
+    /** 
+     * get, set
+     * 
+     * T extends A
+     */
+    gf4: <T extends A>(v1: T, v2: T) => T
+    /**
+     * get
+     * 
+     * T extends A
+     * U extends A & B
+     */
+    readonly gf5: <T extends A, U extends A & B>(v1: T, v2: U) => U
+    /**
+     * get, set
+     * 
+     * T extends A
+     * U extends A & B
+     */
+    gf6: <T extends A, U extends A & B>(v1: T, v2: U) => U
+
+    /** get */
+    readonly arrayify: <T>(obj: T | T[]) => T[];
+    
+    /** get */
+    readonly izi1: (v1: string, v2: string) => void;
+    /** get, set */
+    izi3: (v1: string, v2: string) => void;
+    /** get */
+    readonly izi4: <T>(v1: T, v2: T) => T;
+    /** get, set */
+    izi5: <T>(v1: T, v2: T) => T;
+
+    /** get */
+    readonly t1: [string, string];
+    /** get */
+    readonly ft1: <T>(vs: [T, T]) => T;
+    /** get, set */
+    ft2: <T>(vs: [T, T]) => T;
+
+    /** 
+     * get
+     * 
+     * v2 optional
+     */
+    readonly o1: <T>(v1: T, v2?: T) => T;
+    /** 
+     * get, set
+     * 
+     * v2 optional
+     */
+    o2: <T>(v1: T, v2?: T) => T;
+    /** 
+     * get
+     * 
+     * v2 optional
+     */
+    readonly o3: <T>(v1: T, v2?: [T, T]) => T;
+    /** 
+     * get, set
+     * 
+     * v2 optional
+     */
+    o4: <T>(v1: T, v2?: [T, T]) => T;
+
+    /** function */
+    ff1<T>(f: ((value: T) => T)): ((value: T) => T);
+    /** function */
+    ff2<T>(f: ((value: T) => T), v: T): string;
+    /** function */
+    ff3<T>(v1: T, v2: T | string): T | number
+}

--- a/test/fragments/regressions/#401-variable-generic.d.ts
+++ b/test/fragments/regressions/#401-variable-generic.d.ts
@@ -1,8 +1,4 @@
 //todo: root variable (-> `let`)
-//todo: interface
-    //todo: optional field (`value?: ...`)
-//todo: class:
-    //todo: static
 
 export interface A { readonly name: string }
 export interface B { readonly id: number }
@@ -320,7 +316,7 @@ export interface I {
 }
 
 export class C {
-       /** get */
+    /** get */
     readonly v1: string;
 
     /** get */
@@ -447,4 +443,135 @@ export class C {
     ff2<T>(f: ((value: T) => T), v: T): string;
     /** function */
     ff3<T>(v1: T, v2: T | string): T | number 
+}
+
+/** static */
+export class CS {
+    /** get */
+    static readonly v1: string;
+
+    /** get */
+    static readonly f1: (value: string) => number;
+
+    /** get */
+    static readonly f2: <T>(value: T) => number;
+    /** get */
+    static readonly f3: <T>(value: string) => T;
+    /** get */
+    static readonly f4: <T>(value: T) => T;
+
+    /** get, set */
+    static f5: <T>(value: T) => T;
+    /** get, set */
+    static f6: <T>(value: T) => T;
+
+    /** get */
+    static readonly f7: <T>(v1: T, v2: T) => T;
+    /** get */
+    static readonly f8: <T>(v1: T | string, v2: string | number | T) => T;
+
+    /** get */
+    static readonly f9: <T>(f1: ((v1: T, v2: T) => T), f2: ((v1: string | T, v2: T | number) => string | T)) => T | string
+    /** get, set */
+    static f10: <T>(f1: ((v1: T, v2: T) => T), f2: ((v1: string | T, v2: T | number) => string | T)) => T | string
+
+    /** get */
+    static readonly f11: <T>(v1: T, v2: T) => T;
+    /** get, set */
+    static f12: <T>(v1: T, v2: T) => T;
+
+    /** get */
+    static readonly f13: (v1: string, v2: string) => string;
+    /** get, set */
+    static f14: (v1: string, v2: string) => string;
+
+    /** 
+     * get 
+     * 
+     * T extends A
+     */
+    static readonly gf1: <T extends A>(value: T) => T
+    /** 
+     * get, set
+     * 
+     * T extends A
+     */
+    static gf2: <T extends A>(value: T) => T
+    /** 
+     * get 
+     * 
+     * T extends A
+     */
+    static readonly gf3: <T extends A>(v1: T, v2: T) => T
+    /** 
+     * get, set
+     * 
+     * T extends A
+     */
+    static gf4: <T extends A>(v1: T, v2: T) => T
+    /**
+     * get
+     * 
+     * T extends A
+     * U extends A & B
+     */
+    static readonly gf5: <T extends A, U extends A & B>(v1: T, v2: U) => U
+    /**
+     * get, set
+     * 
+     * T extends A
+     * U extends A & B
+     */
+    static gf6: <T extends A, U extends A & B>(v1: T, v2: U) => U
+
+    /** get */
+    static readonly arrayify: <T>(obj: T | T[]) => T[];
+    
+    /** get */
+    static readonly izi1: (v1: string, v2: string) => void;
+    /** get, set */
+    static izi3: (v1: string, v2: string) => void;
+    /** get */
+    static readonly izi4: <T>(v1: T, v2: T) => T;
+    /** get, set */
+    static izi5: <T>(v1: T, v2: T) => T;
+
+    /** get */
+    static readonly t1: [string, string];
+    /** get */
+    static readonly ft1: <T>(vs: [T, T]) => T;
+    /** get, set */
+    static ft2: <T>(vs: [T, T]) => T;
+
+    /** 
+     * get
+     * 
+     * v2 optional
+     */
+    static readonly o1: <T>(v1: T, v2?: T) => T;
+    /** 
+     * get, set
+     * 
+     * v2 optional
+     */
+    static o2: <T>(v1: T, v2?: T) => T;
+    /** 
+     * get
+     * 
+     * v2 optional
+     */
+    static readonly o3: <T>(v1: T, v2?: [T, T]) => T;
+    /** 
+     * get, set
+     * 
+     * v2 optional
+     */
+    static o4: <T>(v1: T, v2?: [T, T]) => T;
+
+    /** function */
+    static ff1<T>(f: ((value: T) => T)): ((value: T) => T);
+    /** function */
+    static ff2<T>(f: ((value: T) => T), v: T): string;
+    /** function */
+    static ff3<T>(v1: T, v2: T | string): T | number 
 }

--- a/test/fragments/regressions/#401-variable-generic.d.ts
+++ b/test/fragments/regressions/#401-variable-generic.d.ts
@@ -1,0 +1,132 @@
+//todo: root variable (-> `let`)
+//todo: interface
+    //todo: optional field (`value?: ...`)
+//todo: class:
+    //todo: static
+
+export interface A { readonly name: string }
+export interface B { readonly id: number }
+export namespace N {
+    /** get */
+    const v1: string;
+
+    /** get */
+    const f1: (value: string) => number;
+
+    /** get */
+    const f2: <T>(value: T) => number;
+    /** get */
+    const f3: <T>(value: string) => T;
+    /** get */
+    const f4: <T>(value: T) => T;
+
+    /** get, set */
+    let f5: <T>(value: T) => T;
+    /** get, set */
+    var f6: <T>(value: T) => T;
+
+    /** get */
+    const f7: <T>(v1: T, v2: T) => T;
+    /** get */
+    const f8: <T>(v1: T | string, v2: string | number | T) => T;
+
+    /** get */
+    const f9: <T>(f1: ((v1: T, v2: T) => T), f2: ((v1: string | T, v2: T | number) => string | T)) => T | string
+    /** get, set */
+    let f10: <T>(f1: ((v1: T, v2: T) => T), f2: ((v1: string | T, v2: T | number) => string | T)) => T | string
+
+    /** get */
+    const f11: <T>(v1: T, v2: T) => T;
+    /** get, set */
+    let f12: <T>(v1: T, v2: T) => T;
+
+    /** 
+     * get 
+     * 
+     * T extends A
+     */
+    const gf1: <T extends A>(value: T) => T
+    /** 
+     * get, set
+     * 
+     * T extends A
+     */
+    let gf2: <T extends A>(value: T) => T
+    /** 
+     * get 
+     * 
+     * T extends A
+     */
+    const gf3: <T extends A>(v1: T, v2: T) => T
+    /** 
+     * get, set
+     * 
+     * T extends A
+     */
+    let gf4: <T extends A>(v1: T, v2: T) => T
+    /**
+     * get
+     * 
+     * T extends A
+     * U extends A & B
+     */
+    const gf5: <T extends A, U extends A & B>(v1: T, v2: U) => U
+    /**
+     * get, set
+     * 
+     * T extends A
+     * U extends A & B
+     */
+    let gf6: <T extends A, U extends A & B>(v1: T, v2: U) => U
+
+    /** get */
+    const arrayify: <T>(obj: T | T[]) => T[];
+    
+    /** get */
+    const izi1: (v1: string, v2: string) => void;
+    /** get, set */
+    let izi3: (v1: string, v2: string) => void;
+    /** get */
+    const izi4: <T>(v1: T, v2: T) => T;
+    /** get, set */
+    let izi5: <T>(v1: T, v2: T) => T;
+
+    /** get */
+    const t1: [string, string];
+    /** get */
+    const ft1: <T>(vs: [T, T]) => T;
+    /** get, set */
+    let ft2: <T>(vs: [T, T]) => T;
+
+    /** 
+     * get
+     * 
+     * v2 optional
+     */
+    const o1: <T>(v1: T, v2?: T) => T;
+    /** 
+     * get, set
+     * 
+     * v2 optional
+     */
+    let o2: <T>(v1: T, v2?: T) => T;
+    /** 
+     * get
+     * 
+     * v2 optional
+     */
+    const o3: <T>(v1: T, v2?: [T, T]) => T;
+    /** 
+     * get, set
+     * 
+     * v2 optional
+     */
+    let o4: <T>(v1: T, v2?: [T, T]) => T;
+
+    /** function */
+    function ff1<T>(f: ((value: T) => T)): ((value: T) => T);
+    /** function */
+    function ff2<T>(f: ((value: T) => T), v: T): string;
+    /** function */
+    function ff3<T>(v1: T, v2: T | string): T | number
+}

--- a/test/fragments/regressions/#401-variable-generic.expected.fs
+++ b/test/fragments/regressions/#401-variable-generic.expected.fs
@@ -6,6 +6,9 @@ open Fable.Core.JS
 
 let [<Import("N","#401-variable-generic")>] n: N.IExports = jsNative
 
+type [<AllowNullLiteral>] IExports =
+    abstract C: CStatic
+
 type [<AllowNullLiteral>] A =
     abstract name: string
 
@@ -197,3 +200,98 @@ type [<AllowNullLiteral>] I =
     abstract ff2: f: ('T -> 'T) * v: 'T -> string
     /// function
     abstract ff3: v1: 'T * v2: U2<'T, string> -> U2<'T, float>
+
+type [<AllowNullLiteral>] C =
+    /// get
+    abstract v1: string
+    /// get
+    abstract f1: string -> float
+    /// get
+    abstract f2: 'T -> float
+    /// get
+    abstract f3: string -> 'T
+    /// get
+    abstract f4: 'T -> 'T
+    /// get, set
+    abstract f5: ('T -> 'T) with get, set
+    /// get, set
+    abstract f6: ('T -> 'T) with get, set
+    /// get
+    abstract f7: 'T -> 'T -> 'T
+    /// get
+    abstract f8: U2<'T, string> -> U3<string, float, 'T> -> 'T
+    /// get
+    abstract f9: ('T -> 'T -> 'T) -> (U2<string, 'T> -> U2<'T, float> -> U2<string, 'T>) -> U2<'T, string>
+    /// get, set
+    abstract f10: (('T -> 'T -> 'T) -> (U2<string, 'T> -> U2<'T, float> -> U2<string, 'T>) -> U2<'T, string>) with get, set
+    /// get
+    abstract f11: 'T -> 'T -> 'T
+    /// get, set
+    abstract f12: ('T -> 'T -> 'T) with get, set
+    /// get 
+    /// 
+    /// T extends A
+    abstract gf1: 'T -> 'T when 'T :> A
+    /// get, set
+    /// 
+    /// T extends A
+    abstract gf2: ('T -> 'T) when 'T :> A with get, set
+    /// get 
+    /// 
+    /// T extends A
+    abstract gf3: 'T -> 'T -> 'T when 'T :> A
+    /// get, set
+    /// 
+    /// T extends A
+    abstract gf4: ('T -> 'T -> 'T) when 'T :> A with get, set
+    /// get
+    /// 
+    /// T extends A
+    /// U extends A & B
+    abstract gf5: 'T -> 'U -> 'U when 'T :> A and 'U :> A and 'U :> B
+    /// get, set
+    /// 
+    /// T extends A
+    /// U extends A & B
+    abstract gf6: ('T -> 'U -> 'U) when 'T :> A and 'U :> A and 'U :> B with get, set
+    /// get
+    abstract arrayify: U2<'T, ResizeArray<'T>> -> ResizeArray<'T>
+    /// get
+    abstract izi1: string -> string -> unit
+    /// get, set
+    abstract izi3: (string -> string -> unit) with get, set
+    /// get
+    abstract izi4: 'T -> 'T -> 'T
+    /// get, set
+    abstract izi5: ('T -> 'T -> 'T) with get, set
+    /// get
+    abstract t1: string * string
+    /// get
+    abstract ft1: 'T * 'T -> 'T
+    /// get, set
+    abstract ft2: ('T * 'T -> 'T) with get, set
+    /// get
+    /// 
+    /// v2 optional
+    abstract o1: 'T -> ('T) option -> 'T
+    /// get, set
+    /// 
+    /// v2 optional
+    abstract o2: ('T -> ('T) option -> 'T) with get, set
+    /// get
+    /// 
+    /// v2 optional
+    abstract o3: 'T -> ('T * 'T) option -> 'T
+    /// get, set
+    /// 
+    /// v2 optional
+    abstract o4: ('T -> ('T * 'T) option -> 'T) with get, set
+    /// function
+    abstract ff1: f: ('T -> 'T) -> ('T -> 'T)
+    /// function
+    abstract ff2: f: ('T -> 'T) * v: 'T -> string
+    /// function
+    abstract ff3: v1: 'T * v2: U2<'T, string> -> U2<'T, float>
+
+type [<AllowNullLiteral>] CStatic =
+    [<EmitConstructor>] abstract Create: unit -> C

--- a/test/fragments/regressions/#401-variable-generic.expected.fs
+++ b/test/fragments/regressions/#401-variable-generic.expected.fs
@@ -105,3 +105,95 @@ module N =
         abstract ff2: f: ('T -> 'T) * v: 'T -> string
         /// function
         abstract ff3: v1: 'T * v2: U2<'T, string> -> U2<'T, float>
+
+type [<AllowNullLiteral>] I =
+    /// get
+    abstract v1: string
+    /// get
+    abstract f1: string -> float
+    /// get
+    abstract f2: 'T -> float
+    /// get
+    abstract f3: string -> 'T
+    /// get
+    abstract f4: 'T -> 'T
+    /// get, set
+    abstract f5: ('T -> 'T) with get, set
+    /// get, set
+    abstract f6: ('T -> 'T) with get, set
+    /// get
+    abstract f7: 'T -> 'T -> 'T
+    /// get
+    abstract f8: U2<'T, string> -> U3<string, float, 'T> -> 'T
+    /// get
+    abstract f9: ('T -> 'T -> 'T) -> (U2<string, 'T> -> U2<'T, float> -> U2<string, 'T>) -> U2<'T, string>
+    /// get, set
+    abstract f10: (('T -> 'T -> 'T) -> (U2<string, 'T> -> U2<'T, float> -> U2<string, 'T>) -> U2<'T, string>) with get, set
+    /// get
+    abstract f11: 'T -> 'T -> 'T
+    /// get, set
+    abstract f12: ('T -> 'T -> 'T) with get, set
+    /// get 
+    /// 
+    /// T extends A
+    abstract gf1: 'T -> 'T when 'T :> A
+    /// get, set
+    /// 
+    /// T extends A
+    abstract gf2: ('T -> 'T) when 'T :> A with get, set
+    /// get 
+    /// 
+    /// T extends A
+    abstract gf3: 'T -> 'T -> 'T when 'T :> A
+    /// get, set
+    /// 
+    /// T extends A
+    abstract gf4: ('T -> 'T -> 'T) when 'T :> A with get, set
+    /// get
+    /// 
+    /// T extends A
+    /// U extends A & B
+    abstract gf5: 'T -> 'U -> 'U when 'T :> A and 'U :> A and 'U :> B
+    /// get, set
+    /// 
+    /// T extends A
+    /// U extends A & B
+    abstract gf6: ('T -> 'U -> 'U) when 'T :> A and 'U :> A and 'U :> B with get, set
+    /// get
+    abstract arrayify: U2<'T, ResizeArray<'T>> -> ResizeArray<'T>
+    /// get
+    abstract izi1: string -> string -> unit
+    /// get, set
+    abstract izi3: (string -> string -> unit) with get, set
+    /// get
+    abstract izi4: 'T -> 'T -> 'T
+    /// get, set
+    abstract izi5: ('T -> 'T -> 'T) with get, set
+    /// get
+    abstract t1: string * string
+    /// get
+    abstract ft1: 'T * 'T -> 'T
+    /// get, set
+    abstract ft2: ('T * 'T -> 'T) with get, set
+    /// get
+    /// 
+    /// v2 optional
+    abstract o1: 'T -> ('T) option -> 'T
+    /// get, set
+    /// 
+    /// v2 optional
+    abstract o2: ('T -> ('T) option -> 'T) with get, set
+    /// get
+    /// 
+    /// v2 optional
+    abstract o3: 'T -> ('T * 'T) option -> 'T
+    /// get, set
+    /// 
+    /// v2 optional
+    abstract o4: ('T -> ('T * 'T) option -> 'T) with get, set
+    /// function
+    abstract ff1: f: ('T -> 'T) -> ('T -> 'T)
+    /// function
+    abstract ff2: f: ('T -> 'T) * v: 'T -> string
+    /// function
+    abstract ff3: v1: 'T * v2: U2<'T, string> -> U2<'T, float>

--- a/test/fragments/regressions/#401-variable-generic.expected.fs
+++ b/test/fragments/regressions/#401-variable-generic.expected.fs
@@ -1,0 +1,107 @@
+// ts2fable 0.0.0
+module rec ``#401-variable-generic``
+open System
+open Fable.Core
+open Fable.Core.JS
+
+let [<Import("N","#401-variable-generic")>] n: N.IExports = jsNative
+
+type [<AllowNullLiteral>] A =
+    abstract name: string
+
+type [<AllowNullLiteral>] B =
+    abstract id: float
+
+module N =
+
+    type [<AllowNullLiteral>] IExports =
+        /// get
+        abstract v1: string
+        /// get
+        abstract f1: string -> float
+        /// get
+        abstract f2: 'T -> float
+        /// get
+        abstract f3: string -> 'T
+        /// get
+        abstract f4: 'T -> 'T
+        /// get, set
+        abstract f5: ('T -> 'T) with get, set
+        /// get, set
+        abstract f6: ('T -> 'T) with get, set
+        /// get
+        abstract f7: 'T -> 'T -> 'T
+        /// get
+        abstract f8: U2<'T, string> -> U3<string, float, 'T> -> 'T
+        /// get
+        abstract f9: ('T -> 'T -> 'T) -> (U2<string, 'T> -> U2<'T, float> -> U2<string, 'T>) -> U2<'T, string>
+        /// get, set
+        abstract f10: (('T -> 'T -> 'T) -> (U2<string, 'T> -> U2<'T, float> -> U2<string, 'T>) -> U2<'T, string>) with get, set
+        /// get
+        abstract f11: 'T -> 'T -> 'T
+        /// get, set
+        abstract f12: ('T -> 'T -> 'T) with get, set
+        /// get 
+        /// 
+        /// T extends A
+        abstract gf1: 'T -> 'T when 'T :> A
+        /// get, set
+        /// 
+        /// T extends A
+        abstract gf2: ('T -> 'T) when 'T :> A with get, set
+        /// get 
+        /// 
+        /// T extends A
+        abstract gf3: 'T -> 'T -> 'T when 'T :> A
+        /// get, set
+        /// 
+        /// T extends A
+        abstract gf4: ('T -> 'T -> 'T) when 'T :> A with get, set
+        /// get
+        /// 
+        /// T extends A
+        /// U extends A & B
+        abstract gf5: 'T -> 'U -> 'U when 'T :> A and 'U :> A and 'U :> B
+        /// get, set
+        /// 
+        /// T extends A
+        /// U extends A & B
+        abstract gf6: ('T -> 'U -> 'U) when 'T :> A and 'U :> A and 'U :> B with get, set
+        /// get
+        abstract arrayify: U2<'T, ResizeArray<'T>> -> ResizeArray<'T>
+        /// get
+        abstract izi1: string -> string -> unit
+        /// get, set
+        abstract izi3: (string -> string -> unit) with get, set
+        /// get
+        abstract izi4: 'T -> 'T -> 'T
+        /// get, set
+        abstract izi5: ('T -> 'T -> 'T) with get, set
+        /// get
+        abstract t1: string * string
+        /// get
+        abstract ft1: 'T * 'T -> 'T
+        /// get, set
+        abstract ft2: ('T * 'T -> 'T) with get, set
+        /// get
+        /// 
+        /// v2 optional
+        abstract o1: 'T -> ('T) option -> 'T
+        /// get, set
+        /// 
+        /// v2 optional
+        abstract o2: ('T -> ('T) option -> 'T) with get, set
+        /// get
+        /// 
+        /// v2 optional
+        abstract o3: 'T -> ('T * 'T) option -> 'T
+        /// get, set
+        /// 
+        /// v2 optional
+        abstract o4: ('T -> ('T * 'T) option -> 'T) with get, set
+        /// function
+        abstract ff1: f: ('T -> 'T) -> ('T -> 'T)
+        /// function
+        abstract ff2: f: ('T -> 'T) * v: 'T -> string
+        /// function
+        abstract ff3: v1: 'T * v2: U2<'T, string> -> U2<'T, float>

--- a/test/fragments/regressions/#401-variable-generic.expected.fs
+++ b/test/fragments/regressions/#401-variable-generic.expected.fs
@@ -8,6 +8,8 @@ let [<Import("N","#401-variable-generic")>] n: N.IExports = jsNative
 
 type [<AllowNullLiteral>] IExports =
     abstract C: CStatic
+    /// static
+    abstract CS: CSStatic
 
 type [<AllowNullLiteral>] A =
     abstract name: string
@@ -331,3 +333,105 @@ type [<AllowNullLiteral>] C =
 
 type [<AllowNullLiteral>] CStatic =
     [<EmitConstructor>] abstract Create: unit -> C
+
+/// static
+type [<AllowNullLiteral>] CS =
+    interface end
+
+/// static
+type [<AllowNullLiteral>] CSStatic =
+    [<EmitConstructor>] abstract Create: unit -> CS
+    /// get
+    abstract v1: string
+    /// get
+    abstract f1: string -> float
+    /// get
+    abstract f2: 'T -> float
+    /// get
+    abstract f3: string -> 'T
+    /// get
+    abstract f4: 'T -> 'T
+    /// get, set
+    abstract f5: ('T -> 'T) with get, set
+    /// get, set
+    abstract f6: ('T -> 'T) with get, set
+    /// get
+    abstract f7: 'T -> 'T -> 'T
+    /// get
+    abstract f8: U2<'T, string> -> U3<string, float, 'T> -> 'T
+    /// get
+    abstract f9: ('T -> 'T -> 'T) -> (U2<string, 'T> -> U2<'T, float> -> U2<string, 'T>) -> U2<'T, string>
+    /// get, set
+    abstract f10: (('T -> 'T -> 'T) -> (U2<string, 'T> -> U2<'T, float> -> U2<string, 'T>) -> U2<'T, string>) with get, set
+    /// get
+    abstract f11: 'T -> 'T -> 'T
+    /// get, set
+    abstract f12: ('T -> 'T -> 'T) with get, set
+    /// get
+    abstract f13: string -> string -> string
+    /// get, set
+    abstract f14: (string -> string -> string) with get, set
+    /// get 
+    /// 
+    /// T extends A
+    abstract gf1: 'T -> 'T when 'T :> A
+    /// get, set
+    /// 
+    /// T extends A
+    abstract gf2: ('T -> 'T) when 'T :> A with get, set
+    /// get 
+    /// 
+    /// T extends A
+    abstract gf3: 'T -> 'T -> 'T when 'T :> A
+    /// get, set
+    /// 
+    /// T extends A
+    abstract gf4: ('T -> 'T -> 'T) when 'T :> A with get, set
+    /// get
+    /// 
+    /// T extends A
+    /// U extends A & B
+    abstract gf5: 'T -> 'U -> 'U when 'T :> A and 'U :> A and 'U :> B
+    /// get, set
+    /// 
+    /// T extends A
+    /// U extends A & B
+    abstract gf6: ('T -> 'U -> 'U) when 'T :> A and 'U :> A and 'U :> B with get, set
+    /// get
+    abstract arrayify: U2<'T, ResizeArray<'T>> -> ResizeArray<'T>
+    /// get
+    abstract izi1: string -> string -> unit
+    /// get, set
+    abstract izi3: (string -> string -> unit) with get, set
+    /// get
+    abstract izi4: 'T -> 'T -> 'T
+    /// get, set
+    abstract izi5: ('T -> 'T -> 'T) with get, set
+    /// get
+    abstract t1: string * string
+    /// get
+    abstract ft1: 'T * 'T -> 'T
+    /// get, set
+    abstract ft2: ('T * 'T -> 'T) with get, set
+    /// get
+    /// 
+    /// v2 optional
+    abstract o1: 'T -> ('T) option -> 'T
+    /// get, set
+    /// 
+    /// v2 optional
+    abstract o2: ('T -> ('T) option -> 'T) with get, set
+    /// get
+    /// 
+    /// v2 optional
+    abstract o3: 'T -> ('T * 'T) option -> 'T
+    /// get, set
+    /// 
+    /// v2 optional
+    abstract o4: ('T -> ('T * 'T) option -> 'T) with get, set
+    /// function
+    abstract ff1: f: ('T -> 'T) -> ('T -> 'T)
+    /// function
+    abstract ff2: f: ('T -> 'T) * v: 'T -> string
+    /// function
+    abstract ff3: v1: 'T * v2: U2<'T, string> -> U2<'T, float>

--- a/test/fragments/regressions/#401-variable-generic.expected.fs
+++ b/test/fragments/regressions/#401-variable-generic.expected.fs
@@ -44,6 +44,10 @@ module N =
         abstract f11: 'T -> 'T -> 'T
         /// get, set
         abstract f12: ('T -> 'T -> 'T) with get, set
+        /// get
+        abstract f13: string -> string -> string
+        /// get, set
+        abstract f14: (string -> string -> string) with get, set
         /// get 
         /// 
         /// T extends A
@@ -136,6 +140,10 @@ type [<AllowNullLiteral>] I =
     abstract f11: 'T -> 'T -> 'T
     /// get, set
     abstract f12: ('T -> 'T -> 'T) with get, set
+    /// get
+    abstract f13: string -> string -> string
+    /// get, set
+    abstract f14: (string -> string -> string) with get, set
     /// get 
     /// 
     /// T extends A
@@ -194,6 +202,30 @@ type [<AllowNullLiteral>] I =
     /// 
     /// v2 optional
     abstract o4: ('T -> ('T * 'T) option -> 'T) with get, set
+    /// get
+    /// 
+    /// optional
+    abstract opt1: string option
+    /// get, set
+    /// 
+    /// optional
+    abstract opt2: string option with get, set
+    /// get, set
+    /// 
+    /// optional
+    abstract opt4: ('T -> 'T) option with get, set
+    /// get
+    /// 
+    /// optional
+    abstract opt5: (string -> string -> string) option
+    /// get, set
+    /// 
+    /// optional
+    abstract opt7: (string -> string -> string) option with get, set
+    /// get, set
+    /// 
+    /// optional
+    abstract opt8: ('T -> 'T -> 'T) option with get, set
     /// function
     abstract ff1: f: ('T -> 'T) -> ('T -> 'T)
     /// function
@@ -228,6 +260,10 @@ type [<AllowNullLiteral>] C =
     abstract f11: 'T -> 'T -> 'T
     /// get, set
     abstract f12: ('T -> 'T -> 'T) with get, set
+    /// get
+    abstract f13: string -> string -> string
+    /// get, set
+    abstract f14: (string -> string -> string) with get, set
     /// get 
     /// 
     /// T extends A

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -342,7 +342,7 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
         let fsPath = "test/fragments/monaco/variableInModule.fs"
         testFsFiles tsPaths fsPath  <| fun fsFiles ->
             fsFiles 
-            |> existOnlyOneByName "EditorType" FsType.isVariable
+            |> existOnlyOneByName "EditorType" FsType.isProperty
             |> equal true  
 
     it "globalClass" <| fun _ ->
@@ -535,6 +535,10 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
     // https://github.com/fable-compiler/ts2fable/issues/393
     it "regression #393 Mutable Variables become immutable" <| fun _ ->
         runRegressionTest "#393-mutable-variables-become-immutable"
+
+    // https://github.com/fable-compiler/ts2fable/issues/401
+    it "regression #401 Variable with generic type parameter" <| fun _ ->
+        runRegressionTest "#401-variable-generic"
 
     // https://github.com/fable-compiler/ts2fable/issues/403
     it "regression #403 Invalid Xml Comments because of unescaped chars" <| fun _ ->


### PR DESCRIPTION
Handles only Namespaces/Modules & Interfaces/Classes (-> interface), NOT top-level variables (-> `let` binding).