### PR TITLE
Emit `#nowarn` for obsolete usage & invalid XML comments

### DIFF
--- a/src/bridge.fs
+++ b/src/bridge.fs
@@ -194,6 +194,7 @@ module internal Bridge =
                 ]
             Files = fsFiles
             AbbrevTypes = []
+            AdditionalData = []
         }
         |> fixFsFileOut
 

--- a/test/fragments/babylonjs/Stage.PrivateCtor.expected.fs
+++ b/test/fragments/babylonjs/Stage.PrivateCtor.expected.fs
@@ -1,5 +1,8 @@
 // ts2fable 0.0.0
 module rec Stage.PrivateCtor
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/custom/comments/obsolete.expected.fs
+++ b/test/fragments/custom/comments/obsolete.expected.fs
@@ -1,5 +1,8 @@
 // ts2fable 0.0.0
 module rec obsolete
+
+#nowarn "0044" // disable warnings for `Obsolete` usage
+
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/custom/comments/summary.expected.fs
+++ b/test/fragments/custom/comments/summary.expected.fs
@@ -1,5 +1,8 @@
 // ts2fable 0.0.0
 module rec summary
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/custom/comments/transformToXml.expected.fs
+++ b/test/fragments/custom/comments/transformToXml.expected.fs
@@ -1,5 +1,8 @@
 // ts2fable 0.0.0
 module rec transformToXml
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/custom/comments/types.expected.fs
+++ b/test/fragments/custom/comments/types.expected.fs
@@ -1,5 +1,8 @@
 // ts2fable 0.0.0
 module rec types
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/custom/nowarn/obsolete/complex-deprecated-with-xml-comments.d.ts
+++ b/test/fragments/custom/nowarn/obsolete/complex-deprecated-with-xml-comments.d.ts
@@ -1,0 +1,53 @@
+/**
+ * Some interface
+ */
+export interface I1 {
+    /** function in interface */
+    f1(v1: string): void;
+    /** another function in interface
+     * 
+     * And some code: `1+1`
+     * 
+     */
+    f2(v1: string): void;
+}
+/** Some function */
+export function f1(v1: string): void;
+/** A namespace */
+export namespace N1 {
+    /** interface in namespace */
+    interface I1 {
+        /** function in interface */
+        f1(v1: string): void;
+        /** 
+         * another function in interface
+         * 
+         * @remarks some notes
+         */
+        f2(v1: string): void;
+    }
+    /** function in namespace */
+    function f1(v1: string): void;
+    /** nested namespace */
+    namespace N2 {
+        /** 
+         * deep interface
+         * 
+         * And a link: [ts2fable](https://github.com/fable-compiler/ts2fable)
+         */
+        interface I1 {
+            /** 
+             * function in interface
+             * 
+             * @param value a value
+             * 
+             * @deprecated use something else
+             */
+            f1(v1: string): void;
+            /** another function in interface */
+            f2(v1: string): void;
+        }
+        /** deep function */
+        function f1(v1: string): void;
+    }
+}

--- a/test/fragments/custom/nowarn/obsolete/complex-multiple-deprecated.d.ts
+++ b/test/fragments/custom/nowarn/obsolete/complex-multiple-deprecated.d.ts
@@ -1,0 +1,28 @@
+export interface I1 {
+    f1(v1: string): void;
+    f2(v1: string): void;
+}
+/**
+ * @deprecated use something else
+ */
+export function f1(v1: string): void;
+export namespace N1 {
+    interface I1 {
+        /**
+         * @deprecated use something else
+         */
+        f1(v1: string): void;
+        f2(v1: string): void;
+    }
+    function f1(v1: string): void;
+    namespace N2 {
+        interface I1 {
+            /**
+             * @deprecated use something else
+             */
+            f1(v1: string): void;
+            f2(v1: string): void;
+        }
+        function f1(v1: string): void;
+    }
+}

--- a/test/fragments/custom/nowarn/obsolete/complex-no-deprecated.d.ts
+++ b/test/fragments/custom/nowarn/obsolete/complex-no-deprecated.d.ts
@@ -1,0 +1,19 @@
+export interface I1 {
+    f1(v1: string): void;
+    f2(v1: string): void;
+}
+export function f1(v1: string): void;
+export namespace N1 {
+    interface I1 {
+        f1(v1: string): void;
+        f2(v1: string): void;
+    }
+    function f1(v1: string): void;
+    namespace N2 {
+        interface I1 {
+            f1(v1: string): void;
+            f2(v1: string): void;
+        }
+        function f1(v1: string): void;
+    }
+}

--- a/test/fragments/custom/nowarn/obsolete/complex-single-deprecated.d.ts
+++ b/test/fragments/custom/nowarn/obsolete/complex-single-deprecated.d.ts
@@ -1,0 +1,22 @@
+export interface I1 {
+    f1(v1: string): void;
+    f2(v1: string): void;
+}
+export function f1(v1: string): void;
+export namespace N1 {
+    interface I1 {
+        f1(v1: string): void;
+        f2(v1: string): void;
+    }
+    function f1(v1: string): void;
+    namespace N2 {
+        interface I1 {
+            /**
+             * @deprecated use something else
+             */
+            f1(v1: string): void;
+            f2(v1: string): void;
+        }
+        function f1(v1: string): void;
+    }
+}

--- a/test/fragments/custom/nowarn/obsolete/deprecated-usage.d.ts
+++ b/test/fragments/custom/nowarn/obsolete/deprecated-usage.d.ts
@@ -1,0 +1,6 @@
+/**
+ * @deprecated use something else
+ */
+interface I {}
+
+type T = string | I;

--- a/test/fragments/custom/nowarn/obsolete/deprecated.d.ts
+++ b/test/fragments/custom/nowarn/obsolete/deprecated.d.ts
@@ -1,0 +1,4 @@
+/**
+ * @deprecated use something else
+ */
+interface I {}

--- a/test/fragments/custom/nowarn/obsolete/no-deprecated.d.ts
+++ b/test/fragments/custom/nowarn/obsolete/no-deprecated.d.ts
@@ -1,0 +1,1 @@
+interface I {}

--- a/test/fragments/custom/nowarn/xml-comments/complex-with-xml-comments-but-no-xml-tags.d.ts
+++ b/test/fragments/custom/nowarn/xml-comments/complex-with-xml-comments-but-no-xml-tags.d.ts
@@ -1,0 +1,35 @@
+/**
+ * Some interface
+ */
+export interface I1 {
+    /** function in interface */
+    f1(v1: string): void;
+    /** another function in interface */
+    f2(v1: string): void;
+}
+/** Some function */
+export function f1(v1: string): void;
+/** A namespace */
+export namespace N1 {
+    /** interface in namespace */
+    interface I1 {
+        /** function in interface */
+        f1(v1: string): void;
+        /** another function in interface */
+        f2(v1: string): void;
+    }
+    /** function in namespace */
+    function f1(v1: string): void;
+    /** nested namespace */
+    namespace N2 {
+        /** deep interface */
+        interface I1 {
+            /** function in interface */
+            f1(v1: string): void;
+            /** another function in interface */
+            f2(v1: string): void;
+        }
+        /** deep function */
+        function f1(v1: string): void;
+    }
+}

--- a/test/fragments/custom/nowarn/xml-comments/complex-with-xml-comments-with-multiple-tags.d.ts
+++ b/test/fragments/custom/nowarn/xml-comments/complex-with-xml-comments-with-multiple-tags.d.ts
@@ -1,0 +1,51 @@
+/**
+ * Some interface
+ */
+export interface I1 {
+    /** function in interface */
+    f1(v1: string): void;
+    /** another function in interface
+     * 
+     * And some code: `1+1`
+     * 
+     */
+    f2(v1: string): void;
+}
+/** Some function */
+export function f1(v1: string): void;
+/** A namespace */
+export namespace N1 {
+    /** interface in namespace */
+    interface I1 {
+        /** function in interface */
+        f1(v1: string): void;
+        /** 
+         * another function in interface
+         * 
+         * @remarks some notes
+         */
+        f2(v1: string): void;
+    }
+    /** function in namespace */
+    function f1(v1: string): void;
+    /** nested namespace */
+    namespace N2 {
+        /** 
+         * deep interface
+         * 
+         * And a link: [ts2fable](https://github.com/fable-compiler/ts2fable)
+         */
+        interface I1 {
+            /** 
+             * function in interface
+             * 
+             * @param value a value
+             */
+            f1(v1: string): void;
+            /** another function in interface */
+            f2(v1: string): void;
+        }
+        /** deep function */
+        function f1(v1: string): void;
+    }
+}

--- a/test/fragments/custom/nowarn/xml-comments/complex-with-xml-comments-with-single-tag.d.ts
+++ b/test/fragments/custom/nowarn/xml-comments/complex-with-xml-comments-with-single-tag.d.ts
@@ -1,0 +1,39 @@
+/**
+ * Some interface
+ */
+export interface I1 {
+    /** function in interface */
+    f1(v1: string): void;
+    /** another function in interface */
+    f2(v1: string): void;
+}
+/** Some function */
+export function f1(v1: string): void;
+/** A namespace */
+export namespace N1 {
+    /** interface in namespace */
+    interface I1 {
+        /** function in interface */
+        f1(v1: string): void;
+        /** another function in interface */
+        f2(v1: string): void;
+    }
+    /** function in namespace */
+    function f1(v1: string): void;
+    /** nested namespace */
+    namespace N2 {
+        /** deep interface */
+        interface I1 {
+            /** 
+             * function in interface
+             * 
+             * @param value a value
+             */
+            f1(v1: string): void;
+            /** another function in interface */
+            f2(v1: string): void;
+        }
+        /** deep function */
+        function f1(v1: string): void;
+    }
+}

--- a/test/fragments/custom/nowarn/xml-comments/complex-without-xml-comments.d.ts
+++ b/test/fragments/custom/nowarn/xml-comments/complex-without-xml-comments.d.ts
@@ -1,0 +1,19 @@
+export interface I1 {
+    f1(v1: string): void;
+    f2(v1: string): void;
+}
+export function f1(v1: string): void;
+export namespace N1 {
+    interface I1 {
+        f1(v1: string): void;
+        f2(v1: string): void;
+    }
+    function f1(v1: string): void;
+    namespace N2 {
+        interface I1 {
+            f1(v1: string): void;
+            f2(v1: string): void;
+        }
+        function f1(v1: string): void;
+    }
+}

--- a/test/fragments/custom/nowarn/xml-comments/ignored-xml-tag.d.ts
+++ b/test/fragments/custom/nowarn/xml-comments/ignored-xml-tag.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Some interface
+ * 
+ * @deprecated use something else
+ */
+export interface I {}

--- a/test/fragments/custom/nowarn/xml-comments/no-xml-comments.d.ts
+++ b/test/fragments/custom/nowarn/xml-comments/no-xml-comments.d.ts
@@ -1,0 +1,19 @@
+export interface I1 {
+    f1(v1: string): void;
+    f2(v1: string): void;
+}
+export function f1(v1: string): void;
+export namespace N1 {
+    interface I1 {
+        f1(v1: string): void;
+        f2(v1: string): void;
+    }
+    function f1(v1: string): void;
+    namespace N2 {
+        interface I1 {
+            f1(v1: string): void;
+            f2(v1: string): void;
+        }
+        function f1(v1: string): void;
+    }
+}

--- a/test/fragments/custom/nowarn/xml-comments/xml-comments-but-no-xml-tags.d.ts
+++ b/test/fragments/custom/nowarn/xml-comments/xml-comments-but-no-xml-tags.d.ts
@@ -1,0 +1,4 @@
+/**
+ * Some interface with a description without any fancy stuff (-> no xml comments)
+ */
+export interface I {}

--- a/test/fragments/custom/nowarn/xml-comments/xml-comments-correct-tags.d.ts
+++ b/test/fragments/custom/nowarn/xml-comments/xml-comments-correct-tags.d.ts
@@ -1,0 +1,6 @@
+/**
+ * A description
+ * 
+ * @param v some value
+ */
+export function f(v: string): string;

--- a/test/fragments/custom/nowarn/xml-comments/xml-comments-with-param-tag.d.ts
+++ b/test/fragments/custom/nowarn/xml-comments/xml-comments-with-param-tag.d.ts
@@ -1,0 +1,4 @@
+/**
+ * @param value some value
+ */
+export function f(v: string): string;

--- a/test/fragments/custom/nowarn/xml-comments/xml-comments-with-summary-tag.d.ts
+++ b/test/fragments/custom/nowarn/xml-comments/xml-comments-with-summary-tag.d.ts
@@ -1,0 +1,5 @@
+/**
+ * Some interface with a description with link (-> summary tag):
+ * [ts2fable](https://github.com/fable-compiler/ts2fable)
+ */
+export interface I {}

--- a/test/fragments/regressions/#301-union-with-parens.expected.fs
+++ b/test/fragments/regressions/#301-union-with-parens.expected.fs
@@ -1,5 +1,8 @@
 // ts2fable 0.0.0
 module rec ``#301-union-with-parens``
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#304-reserved-keywords.expected.fs
+++ b/test/fragments/regressions/#304-reserved-keywords.expected.fs
@@ -1,5 +1,8 @@
 // ts2fable 0.0.0
 module rec ``#304-reserved-keywords``
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#348-getter-setter.expected.fs
+++ b/test/fragments/regressions/#348-getter-setter.expected.fs
@@ -1,5 +1,8 @@
 // ts2fable 0.0.0
 module rec ``#348-getter-setter``
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#393-mutable-variables-become-immutable.expected.fs
+++ b/test/fragments/regressions/#393-mutable-variables-become-immutable.expected.fs
@@ -1,5 +1,8 @@
 // ts2fable 0.0.0
 module rec ``#393-mutable-variables-become-immutable``
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fragments/regressions/#403-xml-comment-escape-chars.expected.fs
+++ b/test/fragments/regressions/#403-xml-comment-escape-chars.expected.fs
@@ -1,5 +1,9 @@
 // ts2fable 0.0.0
 module rec ``#403-xml-comment-escape-chars``
+
+#nowarn "3390" // disable warnings for invalid XML comments
+#nowarn "0044" // disable warnings for `Obsolete` usage
+
 open System
 open Fable.Core
 open Fable.Core.JS

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -447,6 +447,110 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
         let expected = "test/fragments/custom/comments/obsolete.expected.fs"
         convertAndCompareAgainstExpected tsPaths fsPath expected
 
+    // https://github.com/fable-compiler/ts2fable/pull/409
+    let _ = 
+        let nowarnXmlComments = "#nowarn \"3390\""
+        let dataContains text (data: AdditionalData list) =
+            data
+            |> List.map snd
+            |> List.collect id
+            |> List.filter (fun d -> d.TrimStart().StartsWith text)
+            |> List.length
+            |> (=) 1    // just ONE `#nowarn`
+        let testNowarn name nowarnExcpected =
+            let tsPaths = [ sprintf "test/fragments/custom/nowarn/xml-comments/%s.d.ts" name ]
+            let fsPath = sprintf "test/fragments/custom/nowarn/xml-comments/%s.fs" name
+            let fsFileOut = getFsFileOut fsPath tsPaths []
+            // emitFsFileOut fsPath fsFileOut   // write F# file -> for debugging
+            fsFileOut.AdditionalData
+            |> dataContains nowarnXmlComments
+            |> equal nowarnExcpected
+
+        it "nowarn/xml-comments/no xml comments" <| fun _ ->
+            testNowarn "no-xml-comments" false
+
+        it "nowarn/xml-comments/XML comments but without XML tags" <| fun _ ->
+            testNowarn "xml-comments-but-no-xml-tags" false
+
+        it "nowarn/xml-comments/XML comments with summary tag" <| fun _ ->
+            testNowarn "xml-comments-with-summary-tag" true
+
+        it "nowarn/xml-comments/XML comments with param tag" <| fun _ ->
+            testNowarn "xml-comments-with-param-tag" true
+
+        it "nowarn/xml-comments/complex without XML comments" <| fun _ ->
+            testNowarn "complex-without-xml-comments" false
+
+        it "nowarn/xml-comments/complex with XML comments but no xml tags" <| fun _ ->
+            testNowarn "complex-with-xml-comments-but-no-xml-tags" false
+
+        it "nowarn/xml-comments/complex with XML comments and a single tag" <| fun _ ->
+            testNowarn "complex-with-xml-comments-with-single-tag" true
+
+        it "nowarn/xml-comments/complex with XML comments and multiple tags" <| fun _ ->
+            testNowarn "complex-with-xml-comments-with-multiple-tags" true
+
+        it "nowarn/xml-comments/ignored XML tag" <| fun _ ->
+            testNowarn "ignored-xml-tag" false
+
+        it "nowarn/xml-comments/correct tags" <| fun _ ->
+            // This test doesn't need `#nowarn xml comments`:
+            // it contains XML comments, but these are all valid:
+            // * `<summary>` doesn't contain invalid xml
+            // * `<param>` name is correct
+            // -> ideally: no `#nowarn`
+            //
+            // BUT: invalid xml comments require a lot of complex testing (like 'are names correct?')
+            // and some transformations from jsdoc to XML docs aren't that easy and error prone (like `<ref>` to another member)
+            // -> easier to always emit `#nowarn xml comments` when xml comments with at least one tag
+            testNowarn "xml-comments-correct-tags" true
+
+    // https://github.com/fable-compiler/ts2fable/pull/405
+    let _ =
+        let nowarnXmlComments = "#nowarn \"0044\""
+        let dataContains text (data: AdditionalData list) =
+            data
+            |> List.map snd
+            |> List.collect id
+            |> List.filter (fun d -> d.TrimStart().StartsWith text)
+            |> List.length
+            |> (=) 1    // just ONE `#nowarn`
+        let testNowarn name nowarnExcpected =
+            let tsPaths = [ sprintf "test/fragments/custom/nowarn/obsolete/%s.d.ts" name ]
+            let fsPath = sprintf "test/fragments/custom/nowarn/obsolete/%s.fs" name
+            let fsFileOut = getFsFileOut fsPath tsPaths []
+            // emitFsFileOut fsPath fsFileOut   // write F# file -> for debugging
+            fsFileOut.AdditionalData
+            |> dataContains nowarnXmlComments
+            |> equal nowarnExcpected
+
+        it "nowarn/obsolete/no deprecated" <| fun _ ->
+            testNowarn "no-deprecated" false
+
+        it "nowarn/obsolete/deprecated" <| fun _ ->
+            testNowarn "deprecated" true
+
+        it "nowarn/obsolete/complex-no-deprecated" <| fun _ ->
+            testNowarn "complex-no-deprecated" false
+
+        it "nowarn/obsolete/complex-single-deprecated" <| fun _ ->
+            testNowarn "complex-single-deprecated" true
+
+        it "nowarn/obsolete/complex-multiple-deprecated" <| fun _ ->
+            testNowarn "complex-multiple-deprecated" true
+
+        it "nowarn/obsolete/complex-deprecated-width-xml-comments" <| fun _ ->
+            testNowarn "complex-deprecated-with-xml-comments" true
+
+        it "nowarn/obsolete/deprecated usage" <| fun _ ->
+            // in ideal case:
+            // `#nowarn obsolete` is only emitted when an obsolete type/function/whatever is used
+            // -> only this unit test should contain `#nowarn obsolete`
+            //
+            // BUT: detecting usage is way harder than detecting `@deprecated` 
+            // -> emit `#nowarn` for `@deprecated` instead of just usage
+            testNowarn "deprecated-usage" true
+
     // https://github.com/fable-compiler/ts2fable/pull/275
     it "regression #275 remove private members" <| fun _ ->
         runRegressionTest "#275-private-members"

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -16,6 +16,8 @@ open ts2fable.Keywords
 
 let [<Global>] describe (msg: string) (f: unit->unit): unit = jsNative
 let [<Global>] it (msg: string) (f: unit->unit): unit = jsNative
+/// Focus on this test. Other thests aren't execute, just `itOnly` tests.
+let [<Global("it.only")>] itOnly (msg: string) (f: unit->unit): unit = jsNative
 
 // use only to debug single test
 let [<Emit("it.only($0,$1)")>] only (msg: string) (f: unit->unit): unit = jsNative
@@ -90,7 +92,7 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
         |> List.head
         |> fun md -> md.Types
     
-    let getTopVarialbles fsFiles = 
+    let getTopVariables fsFiles = 
         fsFiles
         |> getTopTypes
         |> List.choose FsType.asVariable 
@@ -150,7 +152,7 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
         let fsPath = "test/fragments/reactxp/duplicatedVariableExports.fs"
         testFsFiles tsPaths fsPath  <| fun fsFiles ->
             fsFiles
-            |> getTopVarialbles 
+            |> getTopVariables 
             |> List.countBy(fun vb -> vb.Name)
             |> List.forall(fun (_,l) -> l = 1)
             |> equal true


### PR DESCRIPTION
Fixes #405: `#nowarn` for obsolete usage
* Usage is quite hard to detect -> always emit when there's at least one
`Obsolete` (`@deprected` in Typescript)

Fixes #409: `#nowarn` for invalid xml comments
* Invalid xml comments aren't easy to detect (invalid namings,
difference in paths for references, ...) -> always emit when there's a
least on XML comment with tags

Add `AdditionalData` on `FsFileOut`: Text that is printed at specified
location in output file.
Used for `#nowarn`, but is quite useful for logging output too.

Add `itOnly`: only execute these tests (`it.only` in mocha)