### PR TITLE
--noresizearray, --convertpropfns (issues #428, 429)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ts2fable",
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/config.fs
+++ b/src/config.fs
@@ -1,0 +1,12 @@
+module Config
+
+let mutable EmitResizeArray = true
+let mutable ConvertPropertyFunctions = false
+
+let Reset() =
+    EmitResizeArray <- true
+    ConvertPropertyFunctions <- false
+
+module OptionNames =
+    let NoEmitResizeArray = "--noresizearray"
+    let ConvertPropertyFunctions = "--convertpropfns"

--- a/src/config.fs
+++ b/src/config.fs
@@ -10,3 +10,30 @@ let Reset() =
 module OptionNames =
     let NoEmitResizeArray = "--noresizearray"
     let ConvertPropertyFunctions = "--convertpropfns"
+    let Exports = "--export"
+    let Help = "--help"
+    let Version = "--version"
+
+let Options =
+    [
+        (OptionNames.Exports,
+         "Collect from multiple TS files" )
+
+        (OptionNames.NoEmitResizeArray,
+         "Use 'T[] instead of ResizeArray<'T>")
+
+        (OptionNames.ConvertPropertyFunctions,
+         "Convert lambda properties to member functions")
+
+        (OptionNames.Version,
+         "Show tool version" )
+
+        (OptionNames.Help,
+         "Show command usage" )
+
+         ]
+
+let Usage() =
+    Options
+        |> List.map (fun (opt,desc) -> sprintf "%-20s %s\n" opt desc)
+        |> List.fold (+) ""

--- a/src/ts2fable.fs
+++ b/src/ts2fable.fs
@@ -35,7 +35,9 @@ let main (argv: string[]): int =
         if Array.contains "-v" argv || Array.contains "--version" argv
         then printfn "%s" Version.version
         if Array.length argv < 2 || Array.contains "-h" argv || Array.contains "--help" argv
-        then printfn "Usage: ts2fable some.d.ts src/Some.fs"
+        then
+            printfn "Usage: ts2fable some.d.ts src/Some.fs"
+            printfn "Options:\n%s" (Config.Usage())
         else parseArgs argv
         ``process``.exitCode <- 0.0
         0

--- a/src/ts2fable.fs
+++ b/src/ts2fable.fs
@@ -15,6 +15,8 @@ let parseArgs (args: string[]) =
     let exports = args |> getArgs (fun s -> s = "-e" || s = "--exports")
     let fsPaths = args |> Array.filter (fun s -> s.EndsWith ".fs") |> Array.toList
     let tsPaths = args |> Array.filter (fun s -> s.EndsWith ".ts") |> Array.toList
+    Config.EmitResizeArray <- not (args |> Array.contains (Config.OptionNames.NoEmitResizeArray))
+    Config.ConvertPropertyFunctions <- args |> Array.contains (Config.OptionNames.ConvertPropertyFunctions)
     if List.isEmpty fsPaths then failwithf "Please provide the path to the F# file to be written."
     if List.isEmpty tsPaths then failwithf "Please provide the path to a TypeScript file."
     // print ts2fable version

--- a/src/ts2fable.fsproj
+++ b/src/ts2fable.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <!-- 
+    <!--
       Symbol required when cli build with fable: TS2FABLE_STANDALONE
       (Not required in .NET build)
 
@@ -10,6 +10,7 @@
     -->
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="config.fs" />
     <Compile Include="node/fileSystem.fs" />
     <Compile Include="TypeScript.fs" />
     <Compile Include="keywords.fs" />

--- a/test/fragments/regressions/#428-noresizearray.d.ts
+++ b/test/fragments/regressions/#428-noresizearray.d.ts
@@ -1,0 +1,7 @@
+//--noresizearray
+declare class Appwrite {
+    account: {
+        createDocument: string[]
+    };
+}
+export { Appwrite };

--- a/test/fragments/regressions/#428-noresizearray.expected.fs
+++ b/test/fragments/regressions/#428-noresizearray.expected.fs
@@ -1,0 +1,18 @@
+// ts2fable 0.0.0
+module rec ``#428-noresizearray``
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+type [<AllowNullLiteral>] IExports =
+    abstract Appwrite: AppwriteStatic
+
+type [<AllowNullLiteral>] Appwrite =
+    abstract account: AppwriteAccount with get, set
+
+type [<AllowNullLiteral>] AppwriteStatic =
+    [<EmitConstructor>] abstract Create: unit -> Appwrite
+
+type [<AllowNullLiteral>] AppwriteAccount =
+    abstract createDocument: string[] with get, set

--- a/test/fragments/regressions/#429-convertpropfns.d.ts
+++ b/test/fragments/regressions/#429-convertpropfns.d.ts
@@ -1,0 +1,7 @@
+//--convertpropfns
+declare class Appwrite {
+    account: {
+        createDocument: (name: string) => Document;
+    };
+}
+export { Appwrite };

--- a/test/fragments/regressions/#429-convertpropfns.expected.fs
+++ b/test/fragments/regressions/#429-convertpropfns.expected.fs
@@ -1,0 +1,18 @@
+// ts2fable 0.8.0
+module rec ``#429-convertpropfns``
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+type [<AllowNullLiteral>] IExports =
+    abstract Appwrite: AppwriteStatic
+
+type [<AllowNullLiteral>] Appwrite =
+    abstract account: AppwriteAccount with get, set
+
+type [<AllowNullLiteral>] AppwriteStatic =
+    [<EmitConstructor>] abstract Create: unit -> Appwrite
+
+type [<AllowNullLiteral>] AppwriteAccount =
+    abstract createDocument: name: string -> Document

--- a/web-app/App.fs
+++ b/web-app/App.fs
@@ -15,15 +15,18 @@ type Model =
     { HtmlCode : string
       FSharpCode : string
       HtmlEditorState : EditorState
-      FSharpEditorState : EditorState }
+      FSharpEditorState : EditorState
+      }
 
 type Msg =
     | HtmlEditorLoaded
     | FSharpEditorLoaded
     | OnHtmlChange of string
     | UpdateFSharpCode
+    | ToggleConfigEmitResizeArray
+    | ToggleConfigConvertPropertyFunctions
 
-let ts2fable s = 
+let ts2fable s =
     printfn "// Placeholder for ts2fable lib\n"
     s |> getFsFileOutWithText |> emitFsFileOutAsText
 
@@ -47,6 +50,14 @@ let update msg model =
     | UpdateFSharpCode ->
         { model with FSharpCode =
                         ts2fable model.HtmlCode }, Cmd.none
+
+    | ToggleConfigEmitResizeArray ->
+        Config.EmitResizeArray <- not (Config.EmitResizeArray)
+        model, Cmd.ofMsg UpdateFSharpCode
+
+    | ToggleConfigConvertPropertyFunctions ->
+        Config.ConvertPropertyFunctions <- not (Config.ConvertPropertyFunctions)
+        model, Cmd.ofMsg UpdateFSharpCode
 
 open Fable.React
 open Fable.React.Props
@@ -103,7 +114,7 @@ let private navbarItem text sampleCode dispatch =
     Navbar.Item.a [ Navbar.Item.Props [ OnClick (fun _ -> OnHtmlChange sampleCode |> dispatch)] ]
         [ str text ]
 
-let private navbar dispatch =
+let private navbar model dispatch =
     Navbar.navbar [ Navbar.IsFixedTop ]
         [ Navbar.Brand.div [ ]
             [ Navbar.Item.a [ ]
@@ -118,7 +129,26 @@ let private navbar dispatch =
                     [ navbarItem "Monaco" Samples.monaco dispatch
                       navbarItem "Mocha" Samples.mocha dispatch
                       navbarItem "chai" Samples.chai dispatch
-                      navbarItem "Typescript" Samples.typescript dispatch ] ] ]
+                      navbarItem "Typescript" Samples.typescript dispatch ]
+                ]
+              Navbar.Item.div [] [
+                  span [] [ str (Config.OptionNames.NoEmitResizeArray) ]
+                  input [
+                      Type "checkbox"
+                      Checked (not Config.EmitResizeArray)
+                      OnChange (fun e -> dispatch ToggleConfigEmitResizeArray)
+                      ]
+              ]
+              Navbar.Item.div [] [
+                  span [] [ str (Config.OptionNames.ConvertPropertyFunctions) ]
+                  input [
+                      Type "checkbox"
+                      Checked (Config.ConvertPropertyFunctions)
+                      OnChange (fun e -> dispatch ToggleConfigConvertPropertyFunctions)
+                      ]
+              ]
+
+            ]
           Navbar.End.div [ ]
             [ Navbar.Item.div [ ]
                 [ Button.a [ Button.Props [ Href "https://github.com/fable-compiler/ts2fable" ]
@@ -135,7 +165,7 @@ let view model dispatch =
         | _ -> false
 
     div [ ]
-        [ navbar dispatch
+        [ navbar model dispatch
           div [ Class "page-content" ]
             [ PageLoader.pageLoader [ PageLoader.IsActive isLoading
                                       PageLoader.Color IsWhite ]

--- a/web-app/App.fs
+++ b/web-app/App.fs
@@ -132,20 +132,24 @@ let private navbar model dispatch =
                       navbarItem "Typescript" Samples.typescript dispatch ]
                 ]
               Navbar.Item.div [] [
-                  span [] [ str (Config.OptionNames.NoEmitResizeArray) ]
-                  input [
-                      Type "checkbox"
-                      Checked (not Config.EmitResizeArray)
-                      OnChange (fun e -> dispatch ToggleConfigEmitResizeArray)
-                      ]
+                  span [ Title (Config.Options |> List.find (fun (n, _) -> n = Config.OptionNames.NoEmitResizeArray) |> snd) ] [
+                    span [] [ str (Config.OptionNames.NoEmitResizeArray) ]
+                    input [
+                        Type "checkbox"
+                        Checked (not Config.EmitResizeArray)
+                        OnChange (fun e -> dispatch ToggleConfigEmitResizeArray)
+                        ]
+                  ]
               ]
               Navbar.Item.div [] [
-                  span [] [ str (Config.OptionNames.ConvertPropertyFunctions) ]
-                  input [
-                      Type "checkbox"
-                      Checked (Config.ConvertPropertyFunctions)
-                      OnChange (fun e -> dispatch ToggleConfigConvertPropertyFunctions)
-                      ]
+                  span [ Title (Config.Options |> List.find (fun (n, _) -> n = Config.OptionNames.ConvertPropertyFunctions) |> snd) ] [
+                    span [] [ str (Config.OptionNames.ConvertPropertyFunctions) ]
+                    input [
+                        Type "checkbox"
+                        Checked (Config.ConvertPropertyFunctions)
+                        OnChange (fun e -> dispatch ToggleConfigConvertPropertyFunctions)
+                        ]
+                  ]
               ]
 
             ]

--- a/web-app/sass/main.scss
+++ b/web-app/sass/main.scss
@@ -37,3 +37,7 @@ html {
     right: 2em;
     margin-bottom: 0 !important;
 }
+
+.navbar-item input {
+    margin-left: 0.5rem;
+}


### PR DESCRIPTION
This PR provides options for using `'T[]` instead of `ResizeArray<'T>`, and for generating member functions instead of lambda property getters. See issues #428 #429 for details.

The options are accessible from:
- command line
- web app
- test suite

## Command line usage

```bash
Usage: ts2fable some.d.ts src/Some.fs
Options:
--export             Collect from multiple TS files
--noresizearray      Use 'T[] instead of ResizeArray<'T>
--convertpropfns     Convert lambda properties to member functions
--version            Show tool version
--help               Show command usage
```

## Web App 

<img width="531" alt="image" src="https://user-images.githubusercontent.com/285421/139533890-ac5e6e74-20b3-4c8f-9d67-36c476d5cae4.png">

## Test Suite

Include command line flags in the source `.d.ts`. For example

File: `tests/fragments/regressions/#429-convertpropfns.d.ts`

```typescript
//--convertpropfns
declare class Appwrite {
    account: {
        createDocument: (name: string) => Document;
    };
}
export { Appwrite };
```


