### PR TITLE
Emit `ImportAll(..)` instead of `Import("*",...)`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "ts2fable",
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/print.fs
+++ b/src/print.fs
@@ -496,11 +496,12 @@ let rec printModule (lines: ResizeArray<string>) (indent: string) (md: FsModule)
                 sprintf "%slet %s%s: %s = jsNative" indent
                     (   match vb.Export with
                         | None -> ""
+                        | Some ep when ep.IsGlobal -> "[<Global>] "
                         | Some ep ->
-                            if ep.IsGlobal then
-                                "[<Global>] "
-                            else
-                                sprintf "[<Import(\"%s\",\"%s\")>] " ep.Selector ep.Path
+                            match ep.Selector with
+                            | "*" -> sprintf "[<ImportAll(\"%s\")>] " ep.Path
+                            | "default" -> sprintf "[<ImportDefault(\"%s\")>] " ep.Path
+                            | _ -> sprintf "[<Import(\"%s\",\"%s\")>] " ep.Selector ep.Path
                     )
                     vb.Name (printType vb.Type)
                 |> lines.Add

--- a/test/fragments/babylonjs/SceneLoader.ImportMeshAsync.expected.fs
+++ b/test/fragments/babylonjs/SceneLoader.ImportMeshAsync.expected.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Fable.Core.JS
 
-let [<Import("*","SceneLoader.ImportMeshAsync")>] babylon: BABYLON.IExports = jsNative
+let [<ImportAll("SceneLoader.ImportMeshAsync")>] babylon: BABYLON.IExports = jsNative
 
 module BABYLON =
 

--- a/test/fragments/babylonjs/Stage.PrivateCtor.expected.fs
+++ b/test/fragments/babylonjs/Stage.PrivateCtor.expected.fs
@@ -9,7 +9,7 @@ open Fable.Core.JS
 
 type Array<'T> = System.Collections.Generic.IList<'T>
 
-let [<Import("*","Stage.PrivateCtor")>] babylon: BABYLON.IExports = jsNative
+let [<ImportAll("Stage.PrivateCtor")>] babylon: BABYLON.IExports = jsNative
 
 module BABYLON =
 

--- a/test/fragments/monaco/variableInModule.fs
+++ b/test/fragments/monaco/variableInModule.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Fable.Core.JS
 
-let [<Import("*","variableInModule")>] monaco: Monaco.IExports = jsNative
+let [<ImportAll("variableInModule")>] monaco: Monaco.IExports = jsNative
 
 module Monaco =
 

--- a/test/fragments/react/f5.fs
+++ b/test/fragments/react/f5.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Fable.Core.JS
 
-let [<Import("*","f5")>] react: React.IExports = jsNative
+let [<ImportAll("f5")>] react: React.IExports = jsNative
 
 module React =
 

--- a/test/fragments/reactxp/duplicatedVariableExports.fs
+++ b/test/fragments/reactxp/duplicatedVariableExports.fs
@@ -4,7 +4,7 @@ open System
 open Fable.Core
 open Fable.Core.JS
 
-let [<Import("*","reactxp")>] reactXP: ReactXP.IExports = jsNative
+let [<ImportAll("reactxp")>] reactXP: ReactXP.IExports = jsNative
 
 module ReactXP =
 

--- a/test/fragments/reactxp/multiple/ReactXP.fs
+++ b/test/fragments/reactxp/multiple/ReactXP.fs
@@ -36,7 +36,7 @@ module __web_Accessibility =
         [<EmitConstructor>] abstract Create: unit -> Accessibility
 
 module __web_ReactXP =
-    let [<Import("*","ReactXP/web/ReactXP")>] reactXP: ReactXP.IExports = jsNative
+    let [<ImportAll("ReactXP/web/ReactXP")>] reactXP: ReactXP.IExports = jsNative
 
     module ReactXP =
 

--- a/test/fragments/regressions/#431-import-all.d.ts
+++ b/test/fragments/regressions/#431-import-all.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Import *
+ */
+export declare module MyModule {
+    function DoStuff(value: string): void;
+}
+/**
+ * Import named
+ */
+export declare const numberOfStickers: number;

--- a/test/fragments/regressions/#431-import-all.expected.fs
+++ b/test/fragments/regressions/#431-import-all.expected.fs
@@ -1,0 +1,16 @@
+// ts2fable 0.0.0
+module rec ``#431-import-all``
+open System
+open Fable.Core
+open Fable.Core.JS
+
+/// Import *
+let [<ImportAll("#431-import-all")>] myModule: MyModule.IExports = jsNative
+/// Import named
+let [<Import("numberOfStickers","#431-import-all")>] numberOfStickers: float = jsNative
+
+/// Import *
+module MyModule =
+
+    type [<AllowNullLiteral>] IExports =
+        abstract DoStuff: value: string -> unit

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -675,4 +675,8 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
     it "regression #429 Generate member function instead of getter of lambda" <| fun _ ->
         runRegressionTest "#429-convertpropfns"
 
+    // https://github.com/fable-compiler/ts2fable/issues/431
+    it "regression #431 ImportAll instead of Import('*')" <| fun _ ->
+        runRegressionTest "#431-import-all"
+
 )?timeout(15_000)


### PR DESCRIPTION
Output
```fsharp
let [<ImportAll("my-module")>] myModule: MyModule.IExports = jsNative
```
instead of
```fsharp
let [<Import("*", "my-module")>] myModule: MyModule.IExports = jsNative
```

Generate same import (with `*`), see [Fable Docs](https://fable.io/docs/communicate/js-from-fable.html#type-safety-with-imports-and-interfaces)