### PR TITLE
Always surround args in Attributes in parens

### DIFF
--- a/src/print.fs
+++ b/src/print.fs
@@ -116,9 +116,9 @@ let printFunctionName (fn: FsFunction) (name:string): string =
     | FsFunctionKind.Constructor ->
         "[<EmitConstructor>] " |> line.Add
     | FsFunctionKind.Call ->
-        "[<Emit \"$0($1...)\">] " |> line.Add
+        "[<Emit(\"$0($1...)\")>] " |> line.Add
     | FsFunctionKind.StringParam emit ->
-        sprintf  "[<Emit \"%s\">] " emit |> line.Add
+        sprintf  "[<Emit(\"%s\")>] " emit |> line.Add
 
     sprintf "abstract %s" name |> line.Add
 
@@ -447,7 +447,7 @@ let printEnum (lines: ResizeArray<string>) (indent: string) (en: FsEnum) =
             if nameEqualsDefaultFableValue unm v then
                 sprintf "    | %s" unm |> line.Add
             else
-                sprintf "    | [<CompiledName \"%s\">] %s" v unm |> line.Add
+                sprintf "    | [<CompiledName(\"%s\")>] %s" v unm |> line.Add
             sprintf "%s%s" indent (line |> String.concat "") |> lines.Add
     | FsEnumCaseType.Unknown ->
         sprintf "%stype %s =" indent en.Name |> lines.Add
@@ -496,10 +496,10 @@ let printDU (lines: ResizeArray<string>) (indent: string) (du: FsTaggedUnionAlia
                 | FsLiteral.String s ->
                     let s = s.Replace("\"", "\\\"")
                     if nameEqualsDefaultFableValue caseName s then ""
-                    else sprintf "[<CompiledName \"%s\">] " s
-                | FsLiteral.Int i -> sprintf "[<CompiledValue %d>] " i
-                | FsLiteral.Float f -> sprintf "[<CompiledValue %s>] " (string f)
-                | FsLiteral.Bool b -> sprintf "[<CompiledValue %b>] " b
+                    else sprintf "[<CompiledName(\"%s\")>] " s
+                | FsLiteral.Int i -> sprintf "[<CompiledValue(%d)>] " i
+                | FsLiteral.Float f -> sprintf "[<CompiledValue(%s)>] " (string f)
+                | FsLiteral.Bool b -> sprintf "[<CompiledValue(%b)>] " b
             sprintf "%s    | %s%s of %s" indent attr caseName tyStr |> lines.Add
             sprintf "%s    static member inline op_ErasedCast(x: %s) = %s x" indent tyStr caseName |> memberLines.Add
         lines.AddRange(memberLines) // add members

--- a/test/fragments/custom/comments/obsolete.expected.fs
+++ b/test/fragments/custom/comments/obsolete.expected.fs
@@ -104,7 +104,7 @@ type [<AllowNullLiteral>] SomeType =
 type [<AllowNullLiteral>] SomeFunctionType =
     /// Summary: SomeFunctionType
     [<Obsolete("SomeFunctionType is deprecated")>]
-    [<Emit "$0($1...)">] abstract Invoke: a: float * b: string -> string
+    [<Emit("$0($1...)")>] abstract Invoke: a: float * b: string -> string
 
 /// Summary: SomeAlias
 [<Obsolete("SomeAlias is deprecated")>]
@@ -118,8 +118,8 @@ type SomeUnion =
 
 /// Summary: SomeLiteral
 type [<StringEnum>] [<RequireQualifiedAccess>] SomeLiteral =
-    | [<CompiledName "A">] A
-    | [<CompiledName "B">] B
+    | [<CompiledName("A")>] A
+    | [<CompiledName("B")>] B
 
 /// Summary: SomeIntersectionType
 [<Obsolete("SomeIntersectionType is deprecated")>]
@@ -141,10 +141,10 @@ type [<RequireQualifiedAccess>] SomeEnum =
 type [<StringEnum>] [<RequireQualifiedAccess>] SomeStringEnum =
     /// <summary>Summary: <c>A = "A"</c></summary>
     [<Obsolete("A is deprecated")>]
-    | [<CompiledName "A">] A
+    | [<CompiledName("A")>] A
     /// <summary>Summary: <c>B = "B"</c></summary>
     [<Obsolete("B is deprecated")>]
-    | [<CompiledName "B">] B
+    | [<CompiledName("B")>] B
 
 /// Summary: SomeNamespace
 [<Obsolete("SomeNamespace is deprecated")>]

--- a/test/fragments/custom/comments/types.expected.fs
+++ b/test/fragments/custom/comments/types.expected.fs
@@ -153,7 +153,7 @@ type [<AllowNullLiteral>] SomeFunctionType =
     /// SomeFunctionType 
     /// and a link: <see href="https://github.com/fable-compiler/ts2fable">ts2fable</see>
     /// </remarks>
-    [<Emit "$0($1...)">] abstract Invoke: a: float * b: string -> string
+    [<Emit("$0($1...)")>] abstract Invoke: a: float * b: string -> string
 
 /// <summary>Summary: SomeAlias</summary>
 /// <remarks>
@@ -180,8 +180,8 @@ type SomeUnion =
 /// and a link: <see href="https://github.com/fable-compiler/ts2fable">ts2fable</see>
 /// </remarks>
 type [<StringEnum>] [<RequireQualifiedAccess>] SomeLiteral =
-    | [<CompiledName "A">] A
-    | [<CompiledName "B">] B
+    | [<CompiledName("A")>] A
+    | [<CompiledName("B")>] B
 
 /// <summary>Summary: SomeIntersectionType</summary>
 /// <remarks>
@@ -223,14 +223,14 @@ type [<StringEnum>] [<RequireQualifiedAccess>] SomeStringEnum =
     /// `A 
     /// and a link: <see href="https://github.com/fable-compiler/ts2fable">ts2fable</see> = "A"`
     /// </remarks>
-    | [<CompiledName "A">] A
+    | [<CompiledName("A")>] A
     /// <summary>Summary: <c>B = "B"</c></summary>
     /// <remarks>
     /// Remarks:
     /// `B 
     /// and a link: <see href="https://github.com/fable-compiler/ts2fable">ts2fable</see> = "B"`
     /// </remarks>
-    | [<CompiledName "B">] B
+    | [<CompiledName("B")>] B
 
 /// <summary>Summary: SomeNamespace</summary>
 /// <remarks>

--- a/test/fragments/custom/type-literal.expected.fs
+++ b/test/fragments/custom/type-literal.expected.fs
@@ -128,7 +128,7 @@ type UnionBivarianceHack =
 /// <summary>Source: <see href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87">React</see></summary>
 type [<AllowNullLiteral>] RefCallback<'T> =
     /// <summary>Source: <see href="https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L87">React</see></summary>
-    [<Emit "$0($1...)">] abstract Invoke: instance: 'T option -> unit
+    [<Emit("$0($1...)")>] abstract Invoke: instance: 'T option -> unit
 
 type [<AllowNullLiteral>] I1 =
     /// Anon Record
@@ -243,8 +243,8 @@ type [<AllowNullLiteral>] C1Static =
 /// read as Type Literal 
 /// BUT: must be printed as Union
 type [<StringEnum>] [<RequireQualifiedAccess>] E1 =
-    | [<CompiledName "Alpha">] Alpha
-    | [<CompiledName "Beta">] Beta
+    | [<CompiledName("Alpha")>] Alpha
+    | [<CompiledName("Beta")>] Beta
 
 type [<AllowNullLiteral>] C5 =
     abstract v1: string with get, set
@@ -280,9 +280,9 @@ type [<StringEnum>] [<RequireQualifiedAccess>] State =
     | Passed
 
 type [<StringEnum>] [<RequireQualifiedAccess>] IExportsE1 =
-    | [<CompiledName "Alpha">] Alpha
-    | [<CompiledName "Beta">] Beta
+    | [<CompiledName("Alpha")>] Alpha
+    | [<CompiledName("Beta")>] Beta
 
 type [<StringEnum>] [<RequireQualifiedAccess>] IExportsE12 =
-    | [<CompiledName "Gamma">] Gamma
-    | [<CompiledName "Delta">] Delta
+    | [<CompiledName("Gamma")>] Gamma
+    | [<CompiledName("Delta")>] Delta

--- a/test/fragments/monaco/variableInModule.fs
+++ b/test/fragments/monaco/variableInModule.fs
@@ -15,4 +15,4 @@ module Monaco =
         abstract dispose: unit -> unit
 
     type [<AllowNullLiteral>] IEvent<'T> =
-        [<Emit "$0($1...)">] abstract Invoke: listener: ('T -> obj option) * ?thisArg: obj -> IDisposable
+        [<Emit("$0($1...)")>] abstract Invoke: listener: ('T -> obj option) * ?thisArg: obj -> IDisposable

--- a/test/fragments/react-native-fbsdk/stringEnumWithPeriod.fs
+++ b/test/fragments/react-native-fbsdk/stringEnumWithPeriod.fs
@@ -10,10 +10,10 @@ type [<StringEnum>] [<RequireQualifiedAccess>] Permissions =
     | User_friends
     | Email
     | User_about_me
-    | [<CompiledName "user_actions.books">] User_actions_books
-    | [<CompiledName "user_actions.fitness">] User_actions_fitness
-    | [<CompiledName "user_actions.music">] User_actions_music
-    | [<CompiledName "user_actions.news">] User_actions_news
-    | [<CompiledName "user_actions.video">] User_actions_video
+    | [<CompiledName("user_actions.books")>] User_actions_books
+    | [<CompiledName("user_actions.fitness")>] User_actions_fitness
+    | [<CompiledName("user_actions.music")>] User_actions_music
+    | [<CompiledName("user_actions.news")>] User_actions_news
+    | [<CompiledName("user_actions.video")>] User_actions_video
     | User_birthday
     | User_education_history

--- a/test/fragments/react/f2.fs
+++ b/test/fragments/react/f2.fs
@@ -13,8 +13,8 @@ type DOMAttributes = React.DOMAttributes
 type DetailedReactHTMLElement = React.DetailedReactHTMLElement
 
 type [<AllowNullLiteral>] DOMFactory<'P, 'T when 'P :> DOMAttributes<'T> and 'T :> Element> =
-    [<Emit "$0($1...)">] abstract Invoke: ?props: obj * [<ParamArray>] children: ReactNode[] -> DOMElement<'P, 'T>
+    [<Emit("$0($1...)")>] abstract Invoke: ?props: obj * [<ParamArray>] children: ReactNode[] -> DOMElement<'P, 'T>
 
 type [<AllowNullLiteral>] DetailedHTMLFactory<'P, 'T when 'P :> HTMLAttributes<'T> and 'T :> HTMLElement> =
     inherit DOMFactory<'P, 'T>
-    [<Emit "$0($1...)">] abstract Invoke: ?props: obj * [<ParamArray>] children: ReactNode[] -> DetailedReactHTMLElement<'P, 'T>
+    [<Emit("$0($1...)")>] abstract Invoke: ?props: obj * [<ParamArray>] children: ReactNode[] -> DetailedReactHTMLElement<'P, 'T>

--- a/test/fragments/react/f7.fs
+++ b/test/fragments/react/f7.fs
@@ -7,4 +7,4 @@ open Fable.Core.JS
 type SyntheticEvent = React.SyntheticEvent
 
 type [<AllowNullLiteral>] EventHandler<'E when 'E :> SyntheticEvent<obj option>> =
-    [<Emit "$0($1...)">] abstract Invoke: ``event``: 'E -> unit
+    [<Emit("$0($1...)")>] abstract Invoke: ``event``: 'E -> unit

--- a/test/fragments/regressions/#374-string-literal-type-argument-with-space.expected.fs
+++ b/test/fragments/regressions/#374-string-literal-type-argument-with-space.expected.fs
@@ -6,16 +6,16 @@ open Fable.Core.JS
 
 
 type [<AllowNullLiteral>] A =
-    [<Emit "$0.on('Hello Space')">] abstract on_Hello_Space: unit -> unit
-    [<Emit "$0.on('Hello	Tab')">] abstract on_Hello_Tab: unit -> unit
-    [<Emit "$0.on('Hello Multiple Words')">] abstract on_Hello_Multiple_Words: unit -> unit
-    [<Emit "$0.on('Hello   Multiple Spaces')">] abstract on_Hello___Multiple_Spaces: unit -> unit
-    // [<Emit "$0.on('Hello☕Invalid')">] abstract ``on_Hello☕Invalid``: unit -> unit
-    // [<Emit "$0.on('Hello ☕ Invalid With Spaces')">] abstract ``on_Hello_☕_Invalid_With_Spaces``: unit -> unit
-    [<Emit "$0.on('(╯°□°）╯︵ ┻━┻')">] abstract ``on_(╯°□°）╯︵_┻━┻``: unit -> unit
-    [<Emit "$0.on('post-require')">] abstract ``on_post-require``: unit -> unit
+    [<Emit("$0.on('Hello Space')")>] abstract on_Hello_Space: unit -> unit
+    [<Emit("$0.on('Hello	Tab')")>] abstract on_Hello_Tab: unit -> unit
+    [<Emit("$0.on('Hello Multiple Words')")>] abstract on_Hello_Multiple_Words: unit -> unit
+    [<Emit("$0.on('Hello   Multiple Spaces')")>] abstract on_Hello___Multiple_Spaces: unit -> unit
+    // [<Emit("$0.on('Hello☕Invalid')")>] abstract ``on_Hello☕Invalid``: unit -> unit
+    // [<Emit("$0.on('Hello ☕ Invalid With Spaces')")>] abstract ``on_Hello_☕_Invalid_With_Spaces``: unit -> unit
+    [<Emit("$0.on('(╯°□°）╯︵ ┻━┻')")>] abstract ``on_(╯°□°）╯︵_┻━┻``: unit -> unit
+    [<Emit("$0.on('post-require')")>] abstract ``on_post-require``: unit -> unit
 
 type [<StringEnum>] [<RequireQualifiedAccess>] S =
-    | [<CompiledName "Foo">] Foo
-    | [<CompiledName "Hello World">] ``Hello World``
-    // | [<CompiledName "Hello☕">] ``Hello☕``
+    | [<CompiledName("Foo")>] Foo
+    | [<CompiledName("Hello World")>] ``Hello World``
+    // | [<CompiledName("Hello☕")>] ``Hello☕``

--- a/test/fragments/regressions/#438-tagged-union.expected.fs
+++ b/test/fragments/regressions/#438-tagged-union.expected.fs
@@ -17,7 +17,7 @@ module StringKind =
 
     type [<TypeScriptTaggedUnion("kind")>] [<RequireQualifiedAccess>] Shape =
         | Circle of Circle
-        | [<CompiledName "square!">] Square of Square
+        | [<CompiledName("square!")>] Square of Square
         static member inline op_ErasedCast(x: Circle) = Circle x
         static member inline op_ErasedCast(x: Square) = Square x
 
@@ -32,8 +32,8 @@ module NumberKind =
         abstract sideLength: float with get, set
 
     type [<TypeScriptTaggedUnion("kind")>] [<RequireQualifiedAccess>] Shape =
-        | [<CompiledValue 1>] Circle of Circle
-        | [<CompiledValue 2>] Square of Square
+        | [<CompiledValue(1)>] Circle of Circle
+        | [<CompiledValue(2)>] Square of Square
         static member inline op_ErasedCast(x: Circle) = Circle x
         static member inline op_ErasedCast(x: Square) = Square x
 
@@ -48,8 +48,8 @@ module MixedKind =
         abstract sideLength: float with get, set
 
     type [<TypeScriptTaggedUnion("kind")>] [<RequireQualifiedAccess>] Shape =
-        | [<CompiledName "square!">] Square of Square
-        | [<CompiledValue 1>] Circle of Circle
+        | [<CompiledName("square!")>] Square of Square
+        | [<CompiledValue(1)>] Circle of Circle
         static member inline op_ErasedCast(x: Square) = Square x
         static member inline op_ErasedCast(x: Circle) = Circle x
 
@@ -68,8 +68,8 @@ module EnumKind =
         abstract sideLength: float with get, set
 
     type [<TypeScriptTaggedUnion("kind")>] [<RequireQualifiedAccess>] Shape =
-        | [<CompiledValue 1>] Circle of Circle
-        | [<CompiledValue 2>] Square of Square
+        | [<CompiledValue(1)>] Circle of Circle
+        | [<CompiledValue(2)>] Square of Square
         static member inline op_ErasedCast(x: Circle) = Circle x
         static member inline op_ErasedCast(x: Square) = Square x
 
@@ -80,13 +80,13 @@ type [<TypeScriptTaggedUnion("kind")>] [<RequireQualifiedAccess>] S1 =
     static member inline op_ErasedCast(x: {| kind: string; sideLength: float |}) = Square x
 
 type [<TypeScriptTaggedUnion("kind")>] [<RequireQualifiedAccess>] S2 =
-    | [<CompiledValue 1>] Case1 of {| kind: int; radius: float |}
-    | [<CompiledValue 2>] Case2 of {| kind: int; sideLength: float |}
+    | [<CompiledValue(1)>] Case1 of {| kind: int; radius: float |}
+    | [<CompiledValue(2)>] Case2 of {| kind: int; sideLength: float |}
     static member inline op_ErasedCast(x: {| kind: int; radius: float |}) = Case1 x
     static member inline op_ErasedCast(x: {| kind: int; sideLength: float |}) = Case2 x
 
 type [<TypeScriptTaggedUnion("kind")>] [<RequireQualifiedAccess>] S3 =
-    | [<CompiledValue 1>] Circle of {| kind: EnumKind.ShapeKind; radius: float |}
-    | [<CompiledValue 2>] Square of {| kind: EnumKind.ShapeKind; sideLength: float |}
+    | [<CompiledValue(1)>] Circle of {| kind: EnumKind.ShapeKind; radius: float |}
+    | [<CompiledValue(2)>] Square of {| kind: EnumKind.ShapeKind; sideLength: float |}
     static member inline op_ErasedCast(x: {| kind: EnumKind.ShapeKind; radius: float |}) = Circle x
     static member inline op_ErasedCast(x: {| kind: EnumKind.ShapeKind; sideLength: float |}) = Square x


### PR DESCRIPTION
Fable doc uses parens -> use parens here too

Previously: mixed: sometimes parens, sometimes space