### PR TITLE
Fix: Deprecated/Obsolete with Reason spanning multiple lines might result in invalid F# (wrong indentation/alignment)

### DIFF
--- a/test/fragments/regressions/#450-obsolete-multiline.d.ts
+++ b/test/fragments/regressions/#450-obsolete-multiline.d.ts
@@ -1,0 +1,37 @@
+declare namespace ns1 {
+    namespace ns2 {
+        interface SomeInterface {
+            /**
+             * Some Value
+             * 
+             * @deprecated 
+             * Value is deprecated
+             * 
+             * The reason spans multiple lines,  
+             * which might lead to incorrect indentation  
+             * when last line is shorter than indentation
+             * 
+             * !
+             */
+            Alpha: number
+
+            /**
+             * Some Value
+             * 
+             * @deprecated 
+             * Value is deprecated
+             * 
+             * A long last line doesn't need any additional spaces
+             */
+            Beta: number
+
+            /**
+             * Some Value
+             * 
+             * @deprecated 
+             * Value is deprecated. And a single line does never need spaces
+             */
+            Gamma: number
+        }
+    }
+}

--- a/test/fragments/regressions/#450-obsolete-multiline.expected.fs
+++ b/test/fragments/regressions/#450-obsolete-multiline.expected.fs
@@ -1,0 +1,33 @@
+// ts2fable 0.0.0
+module rec ``#450-obsolete-multiline``
+
+#nowarn "0044" // disable warnings for `Obsolete` usage
+
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+module Ns1 =
+
+    module Ns2 =
+
+        type [<AllowNullLiteral>] SomeInterface =
+            /// Some Value
+            [<Obsolete("Value is deprecated
+ 
+The reason spans multiple lines,  
+which might lead to incorrect indentation  
+when last line is shorter than indentation
+
+!"          )>]
+            abstract Alpha: float with get, set
+            /// Some Value
+            [<Obsolete("Value is deprecated
+ 
+A long last line doesn't need any additional spaces")>]
+            abstract Beta: float with get, set
+            /// Some Value
+            [<Obsolete("Value is deprecated. And a single line does never need spaces")>]
+            abstract Gamma: float with get, set
+

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -706,4 +706,8 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
     it "regression #438 Tagged union" <| fun _ ->
         runRegressionTest "#438-tagged-union"
 
+    // https://github.com/fable-compiler/ts2fable/pull/450
+    it "regression #450 Obsolete with multiline reason" <| fun _ ->
+        runRegressionTest "#450-obsolete-multiline"
+
 )?timeout(15_000)


### PR DESCRIPTION
```typescript
declare namespace ns1 {
    namespace ns2 {
        interface SomeInterface {
            /**
             * @deprecated 
             * Value is deprecated
             * etc.
             */
            Value: number
        }
    }
}
```
->
```fsharp
module Ns1 =
    module Ns2 =
        type SomeInterface =
            [<Obsolete("Value is deprecated
etc.")>]
            abstract Value: float with get, set
```
-> Obsolete ends with wrong indentation, must be (at least):
```fsharp
module Ns1 =
    module Ns2 =
        type SomeInterface =
            [<Obsolete("Value is deprecated
etc."       )>]
            abstract Value: float with get, set
```


<br/>
<br/>

This PR ensures attributes end at correct indentation and adds spaces at the the end of arguments if necessary.
