### PR TITLE
Handle extends int enum

### DIFF
--- a/src/bridge.fs
+++ b/src/bridge.fs
@@ -143,6 +143,7 @@ module internal Bridge =
         |> aliasToInterfacePartly
         |> removeKeyOfConstraint
         |> extractGenericParameterDefaults
+        |> fixExtendsEnum   // must be before `removeInvalidGenericConstraints`
         |> removeInvalidGenericConstraints
         |> fixTypesHasESKeywords
         |> extractTypesInGlobalModules

--- a/src/print.fs
+++ b/src/print.fs
@@ -191,16 +191,21 @@ let printGenericTypeConstraint (p: FsGenericTypeParameter): string option =
     match p.Constraint with
     | None -> None
     | Some c ->
-        let formatConstraint = sprintf "%s :> %s" p.Name >> Some
+        let formatTypeConstraint = sprintf "%s :> %s" p.Name >> Some
         let rec printConstraint =
             function
+            | FsType.GenericTypeParameterEnumConstraint FsEnumCaseType.Numeric ->
+                sprintf "%s : enum<int>" p.Name
+                |> Some
+            | FsType.GenericTypeParameterEnumConstraint _ ->
+                None
               // actual type or generic parameter name: `MyType`, `T`
             | FsType.Mapped mp ->
-                formatConstraint mp.Name
+                formatTypeConstraint mp.Name
               // generic type: `MyType<...>
             | FsType.Generic g ->
                 printGeneric g
-                |> formatConstraint
+                |> formatTypeConstraint
               // and: `MyType1 & MyType2` (ts), `'T :> MyType1 and 'T :> MyType2` (F#)
             | FsType.Tuple tp when tp.Kind = FsTupleKind.Intersection ->
                 tp.Types

--- a/src/syntax.fs
+++ b/src/syntax.fs
@@ -437,6 +437,7 @@ type FsType =
     | Import of FsImport
     | TypeLiteral of FsTypeLiteral
     | GenericTypeParameter of FsGenericTypeParameter
+    | GenericTypeParameterEnumConstraint of FsEnumCaseType
     | KeyOf of FsKeyOf
 
 [<RequireQualifiedAccess>]

--- a/test/fragments/regressions/#454-extends-enum.d.ts
+++ b/test/fragments/regressions/#454-extends-enum.d.ts
@@ -1,0 +1,45 @@
+/**
+ * extends int enum
+ * -> `: enum<int>` constraint
+ */
+export declare namespace n {
+    enum RootKind {
+        Alpha = 1,
+        Beta = 2,
+        Gamma = 3,
+        Delta = 4
+    }
+    type SubKind = RootKind.Alpha | RootKind.Gamma;
+
+    interface InterfaceRootKind<TKind extends RootKind> { }
+    interface InterfaceSubKind<TKind extends SubKind> { }
+    interface InterfaceSubValue<TKind extends RootKind.Alpha> { }
+    interface InterfaceSubSet<TKind extends RootKind.Alpha | RootKind.Beta> { }
+
+    function fRootKind<TKind extends RootKind>(value: TKind): TKind
+    function fSub1Kind<TKind extends SubKind>(value: TKind): TKind
+    function fSubValue<TKind extends RootKind.Alpha>(value: TKind): TKind
+    function fSubSet<TKind extends RootKind.Alpha | RootKind.Beta>(value: TKind): TKind
+}
+
+/**
+ * extends string enum
+ * -> remove constraint
+ */
+export declare namespace s {
+    enum MyKind {
+        Alpha = "foo",
+        Beta = "bar",
+        Gamma = "baz",
+    }
+    type SubKind = MyKind.Alpha | MyKind.Gamma;
+    interface InterfaceMyKind<TKind extends MyKind> { }
+    interface InterfaceSubKind<TKind extends SubKind> { }
+    interface InterfaceSubValue<TKind extends MyKind.Alpha> { }
+    interface InterfaceSubSet<TKind extends MyKind.Alpha | MyKind.Beta> { }
+
+    function fMyKind<TKind extends MyKind>(value: TKind): TKind
+    function fSub1Kind<TKind extends SubKind>(value: TKind): TKind
+    function fSubValue<TKind extends MyKind.Alpha>(value: TKind): TKind
+    function fSubSet<TKind extends MyKind.Alpha | MyKind.Beta>(value: TKind): TKind
+}

--- a/test/fragments/regressions/#454-extends-enum.expected.fs
+++ b/test/fragments/regressions/#454-extends-enum.expected.fs
@@ -1,0 +1,84 @@
+// ts2fable 0.0.0
+module rec ``#454-extends-enum``
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+/// <summary>
+/// extends int enum
+/// -&gt; <c>: enum&lt;int&gt;</c> constraint
+/// </summary>
+module N =
+
+    type [<AllowNullLiteral>] IExports =
+        abstract fRootKind: value: 'TKind -> 'TKind when 'TKind : enum<int>
+        abstract fSub1Kind: value: 'TKind -> 'TKind when 'TKind : enum<int>
+        abstract fSubValue: value: 'TKind -> 'TKind when 'TKind : enum<int>
+        abstract fSubSet: value: 'TKind -> 'TKind when 'TKind : enum<int>
+
+    type [<RequireQualifiedAccess>] RootKind =
+        | Alpha = 1
+        | Beta = 2
+        | Gamma = 3
+        | Delta = 4
+
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// RootKind.Alpha | RootKind.Gamma
+    /// </code>
+    /// </remarks>
+    type SubKind =
+        RootKind
+
+    type [<AllowNullLiteral>] InterfaceRootKind<'TKind when 'TKind : enum<int>> =
+        interface end
+
+    type [<AllowNullLiteral>] InterfaceSubKind<'TKind when 'TKind : enum<int>> =
+        interface end
+
+    type [<AllowNullLiteral>] InterfaceSubValue<'TKind when 'TKind : enum<int>> =
+        interface end
+
+    type [<AllowNullLiteral>] InterfaceSubSet<'TKind when 'TKind : enum<int>> =
+        interface end
+
+/// extends string enum
+/// -> remove constraint
+module S =
+
+    type [<AllowNullLiteral>] IExports =
+        abstract fMyKind: value: 'TKind -> 'TKind
+        abstract fSub1Kind: value: 'TKind -> 'TKind
+        abstract fSubValue: value: 'TKind -> 'TKind
+        abstract fSubSet: value: 'TKind -> 'TKind
+
+    type [<StringEnum>] [<RequireQualifiedAccess>] MyKind =
+        | [<CompiledName("foo")>] Alpha
+        | [<CompiledName("bar")>] Beta
+        | [<CompiledName("baz")>] Gamma
+
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// MyKind.Alpha | MyKind.Gamma
+    /// </code>
+    /// </remarks>
+    type SubKind =
+        MyKind
+
+    type [<AllowNullLiteral>] InterfaceMyKind<'TKind> =
+        interface end
+
+    type [<AllowNullLiteral>] InterfaceSubKind<'TKind> =
+        interface end
+
+    type [<AllowNullLiteral>] InterfaceSubValue<'TKind> =
+        interface end
+
+    type [<AllowNullLiteral>] InterfaceSubSet<'TKind> =
+        interface end

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -711,7 +711,10 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
         runRegressionTest "#450-obsolete-multiline"
 
     // https://github.com/fable-compiler/ts2fable/pull/451
-    it "regression #451 union of enum-sub-sets.d" <| fun _ ->
+    it "regression #451 union of enum-sub-sets" <| fun _ ->
         runRegressionTest "#451-union-enum-sub-sets"
 
-)?timeout(15_000)
+    it "regression #454 generic type constraint: extends enum" <| fun _ ->
+        runRegressionTest "#454-extends-enum"
+
+)?timeout(25_000)


### PR DESCRIPTION
```typescript
enum RootKind {
  Alpha = 1,
  Beta = 2,
}
interface InterfaceRootKind<TKind extends RootKind> { }
```

prev:
```fsharp
type [<AllowNullLiteral>] InterfaceRootKind<'TKind when 'TKind :> RootKind> = interface end
```
-> `:> RootKind` is invalid

now:
```fsharp
type [<AllowNullLiteral>] InterfaceRootKind<'TKind when 'TKind : enum<int>> = interface end
```


Note:  
There's no additional XML Comment because that would need handling of outer type instead of just Generic Type Parameter (... and I got lazy... :P )
If we add comments in such cases we should do that for all cases Constraints gets adjusted or removed, not just for enum

<br/>
<br/>

-----------

<br/>
<br/>

Additional:  
Increase timeout for tests (`15s` -> `25s`)

previous master CI test failed (with timeout of a test) -- while the same PR CI run succeeded.

Comparing these two runs ([master](https://ci.appveyor.com/project/fable-compiler/ts2fable/builds/45433280), [PR](https://ci.appveyor.com/project/fable-compiler/ts2fable/builds/45433229)) it seems to be just an "unlucky" run with little CPU allocated: all tests seems to run twice as long (Though that should be still enough for failing test "multiple ts inputs should export one time" (in PR run: `1259ms`))



