### PR TITLE
Fix #423: Invalid DU Case names (special chars)

### DIFF
--- a/src/print.fs
+++ b/src/print.fs
@@ -484,7 +484,7 @@ let printEnum (lines: ResizeArray<string>) (indent: string) (en: FsEnum) =
             printComments lines (indent + "    ") cs.Comments
             printAttributes lines (indent + "    ") cs.Attributes
             let nm = cs.Name
-            let unm = createEnumName nm
+            let unm = createEnumCaseName nm
             let line = ResizeArray()
             sprintf "    | %s" unm |> line.Add
             if cs.Value.IsSome then
@@ -496,8 +496,8 @@ let printEnum (lines: ResizeArray<string>) (indent: string) (en: FsEnum) =
             printComments lines (indent + "    ") cs.Comments
             printAttributes lines (indent + "    ") cs.Attributes
             let nm = cs.Name
-            let v = (cs.Value |> Option.map (fun v -> v.Value) |> Option.defaultValue nm).Replace("\"", "\\\"")
-            let unm = createEnumName nm
+            let v = (cs.Value |> Option.map (fun v -> v.Value) |> Option.defaultValue nm) |> escapeCompiledName
+            let unm = createUnionCaseName nm
             let line = ResizeArray()
             if nameEqualsDefaultFableValue unm v then
                 sprintf "    | %s" unm |> line.Add
@@ -538,7 +538,7 @@ let printDU (lines: ResizeArray<string>) (indent: string) (du: FsTaggedUnionAlia
                         | Some name -> name // if tag is an enum case, use its name
                         | None ->
                             match tag.Value with
-                            | FsLiteral.String s -> createEnumName s // use value as name (like in StringEnum)
+                            | FsLiteral.String s -> createEnumCaseName s // use value as name (like in StringEnum)
                             | _ ->
                                 // use index. would be confusing if it became something like `Case2147483647`
                                 sprintf "Case%d" (index+1)

--- a/src/syntax.fs
+++ b/src/syntax.fs
@@ -601,6 +601,7 @@ let getTypeName (tp: FsType) =
     | FsType.Array t -> t.GetType().ToString()
     | FsType.ExportAssignment t -> t.GetType().ToString()
     | FsType.GenericTypeParameter t -> t.GetType().ToString()
+    | FsType.GenericTypeParameterEnumConstraint t -> t.GetType().ToString()
     | FsType.KeyOf t -> t.GetType().ToString()
     | FsType.None as t -> t.GetType().ToString() + ".None"
     | FsType.TODO as t -> t.GetType().ToString() + ".TODO"
@@ -634,6 +635,7 @@ let getAccessibility (tp: FsType) : FsAccessibility option =
     | FsType.Array _
     | FsType.ExportAssignment _
     | FsType.GenericTypeParameter _
+    | FsType.GenericTypeParameterEnumConstraint _
     | FsType.KeyOf _
     | FsType.None
     | FsType.TODO

--- a/test/fragments/regressions/#423-invalid-du-case-name.d.ts
+++ b/test/fragments/regressions/#423-invalid-du-case-name.d.ts
@@ -1,0 +1,69 @@
+export type CompletionsTriggerCharacter = 
+  | "@"
+  | "."
+  | "+"
+  | "$"
+  | "&"
+  | "["
+  | "]"
+  | "/"
+  | "\""
+  | "\\"
+  | "*"
+  | "`"
+
+  | "'" 
+  | "<" 
+  | "#" 
+  | " " 
+  | "-"
+  | "_"
+
+  | "\t"
+  | "\n"
+  | "\r\n"
+
+  | "////" 
+  | "\\\\\\" 
+  | "@\t\\\n"
+  | "<@\t\\\n>"
+
+  | "A\"B\\C&D+E@F"
+  ; 
+
+export type Unescaped =
+    // Note: above in double-quotations is escaped, while here it isn't escaped!
+  | '"'
+
+/**
+ * Unlike unions, enums can have special chars...
+ */
+declare enum Chars {
+    "@",
+    ".",
+    "+",
+    "$",
+    "&",
+    "[",
+    "]",
+    "/",
+    "\"",
+    "\\",
+    "*",
+    "`",
+    "'",
+    "<",
+    "#",
+    " ",
+    "-",
+    "_",
+    "\t",
+    "\n",
+    "\r\n",
+    "////",
+    "\\\\\\",
+    "@\t\\\n",
+    "<@\t\\\n>",
+    "A\"B\\C&D+E@F"
+}
+

--- a/test/fragments/regressions/#423-invalid-du-case-name.expected.fs
+++ b/test/fragments/regressions/#423-invalid-du-case-name.expected.fs
@@ -1,0 +1,68 @@
+// ts2fable 0.0.0
+module rec ``#423-invalid-du-case-name``
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+type [<StringEnum>] [<RequireQualifiedAccess>] CompletionsTriggerCharacter =
+    | [<CompiledName("@")>] AT
+    | [<CompiledName(".")>] DOT
+    | [<CompiledName("+")>] PLUS
+    | [<CompiledName("$")>] DOLLAR
+    | [<CompiledName("&")>] AMPERSAND
+    | [<CompiledName("[")>] LEFT_SQUARE_BRACKET
+    | [<CompiledName("]")>] RIGHT_SQUARE_BRACKET
+    | [<CompiledName("/")>] SLASH
+    | [<CompiledName("\"")>] QUOTATION
+    | [<CompiledName("\\")>] BACKSLASH
+    | [<CompiledName("*")>] ASTERISK
+    | [<CompiledName("`")>] BACKTICK
+    | [<CompiledName("'")>] ``'``
+    | [<CompiledName("<")>] ``<``
+    | [<CompiledName("#")>] ``#``
+    | [<CompiledName(" ")>] Empty
+    | [<CompiledName("-")>] ``-``
+    | [<CompiledName("_")>] ``_``
+    | [<CompiledName("\t")>] TAB
+    | [<CompiledName("\n")>] LF
+    | [<CompiledName("\r\n")>] CRLF
+    | [<CompiledName("////")>] SLASH_SLASH_SLASH_SLASH
+    | [<CompiledName("\\\\\\")>] BACKSLASH_BACKSLASH_BACKSLASH
+    | [<CompiledName("@\t\\\n")>] AT_TAB_BACKSLASH_LF
+    | [<CompiledName("<@\t\\\n>")>] ``<_AT_TAB_BACKSLASH_LF_>``
+    | [<CompiledName("A\"B\\C&D+E@F")>] A_QUOTATION_B_BACKSLASH_C_AMPERSAND_D_PLUS_E_AT_F
+
+type [<StringEnum>] [<RequireQualifiedAccess>] Unescaped =
+    | [<CompiledName("\"")>] QUOTATION
+
+/// Unlike unions, enums can have special chars...
+type [<RequireQualifiedAccess>] Chars =
+    | AT = 0
+    | ``.`` = 1
+    | ``+`` = 2
+    | ``$`` = 3
+    | ``&`` = 4
+    | ``[`` = 5
+    | ``]`` = 6
+    | ``/`` = 7
+    | ``\"`` = 8
+    | ``\\`` = 9
+    | ``*`` = 10
+    | BACKTICK = 11
+    | ``'`` = 12
+    | ``<`` = 13
+    | ``#`` = 14
+    | `` `` = 15
+    | ``-`` = 16
+    | ``_`` = 17
+    | ``\t`` = 18
+    | ``\n`` = 19
+    | ``\r\n`` = 20
+    | ``////`` = 21
+    | ``\\\\\\`` = 22
+    | ``AT_\t\\\n`` = 23
+    | ``<_AT_\t\\\n>`` = 24
+    | ``A\"B\\C&D+E_AT_F`` = 25
+
+

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -690,6 +690,10 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
     it "regression #425 Link surrounded by parens becomes link containing paren" <| fun _ ->
         runRegressionTest "#425-xml-comment-link-in-parens"
 
+    // https://github.com/fable-compiler/ts2fable/issues/423
+    it "regression #423 invalid DU Case name" <| fun _ ->
+        runRegressionTest "#423-invalid-du-case-name"
+
     // https://github.com/fable-compiler/ts2fable/issues/428
     it "regression #428 Use \"T[]\" instead \"ResizeArray<T>\"" <| fun _ ->
         runRegressionTest "#428-noresizearray"
@@ -714,6 +718,7 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
     it "regression #451 union of enum-sub-sets" <| fun _ ->
         runRegressionTest "#451-union-enum-sub-sets"
 
+    // https://github.com/fable-compiler/ts2fable/pull/454
     it "regression #454 generic type constraint: extends enum" <| fun _ ->
         runRegressionTest "#454-extends-enum"
 


### PR DESCRIPTION
```typescript
export type CompletionsTriggerCharacter = 
  | "@"
  | "."
  | "+"
  | "$"
  | "&"
  | "["
  | "]"
  | "/"
  | "\\"
  | "*"
  | "\""
  | "`"

  | "'" 
  | "<" 
  | "#" 
  | " " 
  | "-"
  | "_"

  | "\t"
  | "\n"
  | "\r\n"

  | "////" 
  | "\\\\\\" 
  | "@\t\\\n"
  | "<@\t\\\n>"

  | "A\"B\\C&D+E@F"
  ; 
```
->
```fsharp
type [<StringEnum>] [<RequireQualifiedAccess>] CompletionsTriggerCharacter =
    | [<CompiledName("@")>] AT
    | [<CompiledName(".")>] DOT
    | [<CompiledName("+")>] PLUS
    | [<CompiledName("$")>] DOLLAR
    | [<CompiledName("&")>] AMPERSAND
    | [<CompiledName("[")>] LEFT_SQUARE_BRACKET
    | [<CompiledName("]")>] RIGHT_SQUARE_BRACKET
    | [<CompiledName("/")>] SLASH
    | [<CompiledName("\\")>] BACKSLASH
    | [<CompiledName("*")>] ASTERISK
    | [<CompiledName("\"")>] QUOTATION
    | [<CompiledName("`")>] BACKTICK
    | [<CompiledName("'")>] ``'``
    | [<CompiledName("<")>] ``<``
    | [<CompiledName("#")>] ``#``
    | [<CompiledName(" ")>] Empty
    | [<CompiledName("-")>] ``-``
    | [<CompiledName("_")>] ``_``
    | [<CompiledName("\t")>] TAB
    | [<CompiledName("\n")>] LF
    | [<CompiledName("\r\n")>] CRLF
    | [<CompiledName("////")>] SLASH_SLASH_SLASH_SLASH
    | [<CompiledName("\\\\\\")>] BACKSLASH_BACKSLASH_BACKSLASH
    | [<CompiledName("@\t\\\n")>] AT_TAB_BACKSLASH_LF
    | [<CompiledName("<@\t\\\n>")>] ``<_AT_TAB_BACKSLASH_LF_>``
    | [<CompiledName("A\"B\\C&D+E@F")>] A_QUOTATION_B_BACKSLASH_C_AMPERSAND_D_PLUS_E_AT_F
```

->
Invalid characters are now written as All-uppercase-words. Separated from other text by `_`.

Note: lower-case and special-char-starts (with `RequireQualifiedAccess`) are allowed only in F# 7.0 and up.  
-> Cases like ` ``-`` ` are still invalid in older F# versions!


Note: for enums special chars are allowed.... -> don't get replaced (`| ``+`` = 1` is ok...).  
With two exceptions (-> get replaced with text):
* `@`: reserved (-> compiler warning)
* `` ` ``  (backtick): technically valid -- but often conflicts with surrounding double-backticks (like directly besides double-backticks or two backticks (-> conflicts with double-backtick end))  
  -> just easier to replace with `BACKTICK` than to handle correctly


<br/>
<br/>

Additional: in `CompiledName`: emit `\r`, `\n` & `\t` as escape sequence (instead of actual string (like actual new line))