### PR TITLE
Handle generic call signature

### DIFF
--- a/src/read.fs
+++ b/src/read.fs
@@ -730,7 +730,7 @@ let readCallSignature (checker: TypeChecker) (cs: CallSignatureDeclaration): FsF
         Kind = FsFunctionKind.Call
         IsStatic = false // TODO ?
         Name = Some "Invoke"
-        TypeParameters = []
+        TypeParameters = cs.typeParameters |> readTypeParameters checker
         Params = cs.parameters |> List.ofSeq |> List.mapi (readParameterDeclaration checker)
         ReturnType =
             match cs.``type`` with

--- a/test/fragments/regressions/#456-generic-call-signature.d.ts
+++ b/test/fragments/regressions/#456-generic-call-signature.d.ts
@@ -1,0 +1,6 @@
+export interface Node {}
+
+export interface NodeVisitor {
+  <T extends Node>(nodes: T)
+  <T extends Node>(nodes: T, test: (node: T) => boolean)
+}

--- a/test/fragments/regressions/#456-generic-call-signature.expected.fs
+++ b/test/fragments/regressions/#456-generic-call-signature.expected.fs
@@ -1,0 +1,13 @@
+// ts2fable 0.0.0
+module rec ``#456-generic-call-signature``
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+type [<AllowNullLiteral>] Node =
+    interface end
+
+type [<AllowNullLiteral>] NodeVisitor =
+    [<Emit("$0($1...)")>] abstract Invoke: nodes: 'T -> unit when 'T :> Node
+    [<Emit("$0($1...)")>] abstract Invoke: nodes: 'T * test: ('T -> bool) -> unit when 'T :> Node

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -722,4 +722,8 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
     it "regression #454 generic type constraint: extends enum" <| fun _ ->
         runRegressionTest "#454-extends-enum"
 
+    // https://github.com/fable-compiler/ts2fable/pull/456
+    it "regression #456 generic call signature" <| fun _ ->
+        runRegressionTest "#456-generic-call-signature"
+
 )?timeout(25_000)


### PR DESCRIPTION
```typescript
export interface Node {}

export interface NodeVisitor {
  <T extends Node>(nodes: T)
  <T extends Node>(nodes: T, test: (node: T) => boolean)
}
```

prev:
```fsharp
type [<AllowNullLiteral>] Node =
    interface end

type [<AllowNullLiteral>] NodeVisitor =
    [<Emit("$0($1...)")>] abstract Invoke: nodes: T -> unit
    [<Emit("$0($1...)")>] abstract Invoke: nodes: T * test: (T -> bool) -> unit
```
-> doesn't handle generic & its constraint

now:
```fsharp
type [<AllowNullLiteral>] Node =
    interface end

type [<AllowNullLiteral>] NodeVisitor =
    [<Emit("$0($1...)")>] abstract Invoke: nodes: 'T -> unit when 'T :> Node
    [<Emit("$0($1...)")>] abstract Invoke: nodes: 'T * test: ('T -> bool) -> unit when 'T :> Node
```