### PR TITLE
Fix: Type Literal with overload generates Anonymous Record with two Properties of same name

### DIFF
--- a/test/fragments/regressions/#457-overload-anon-record.d.ts
+++ b/test/fragments/regressions/#457-overload-anon-record.d.ts
@@ -1,0 +1,7 @@
+export interface StringLiteral {
+  readonly kind: string
+}
+export const createStringLiteral: {
+    (text: string, isSingleQuote?: boolean | undefined): StringLiteral;
+    (text: string, isSingleQuote?: boolean | undefined, hasExtendedUnicodeEscape?: boolean | undefined): StringLiteral;
+};

--- a/test/fragments/regressions/#457-overload-anon-record.expected.fs
+++ b/test/fragments/regressions/#457-overload-anon-record.expected.fs
@@ -1,0 +1,14 @@
+// ts2fable 0.0.0
+module rec ``#457-overload-anon-record``
+open System
+open Fable.Core
+open Fable.Core.JS
+
+let [<Import("createStringLiteral","#457-overload-anon-record")>] createStringLiteral: CreateStringLiteral = jsNative
+
+type [<AllowNullLiteral>] StringLiteral =
+    abstract kind: string
+
+type [<AllowNullLiteral>] CreateStringLiteral =
+    [<Emit("$0($1...)")>] abstract Invoke: text: string * ?isSingleQuote: bool -> StringLiteral
+    [<Emit("$0($1...)")>] abstract Invoke: text: string * ?isSingleQuote: bool * ?hasExtendedUnicodeEscape: bool -> StringLiteral

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -726,4 +726,8 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
     it "regression #456 generic call signature" <| fun _ ->
         runRegressionTest "#456-generic-call-signature"
 
+    // https://github.com/fable-compiler/ts2fable/pull/457
+    itOnly "regression #457 Overload in Anonymous record" <| fun _ ->
+        runRegressionTest "#457-overload-anon-record"
+
 )?timeout(25_000)


### PR DESCRIPTION
```typescript
export const createStringLiteral: {
    (text: string, isSingleQuote?: boolean | undefined): StringLiteral;
    (text: string, isSingleQuote?: boolean | undefined, hasExtendedUnicodeEscape?: boolean | undefined): StringLiteral;
};
```

prev:
```fsharp
let [<Import("createStringLiteral","module")>] createStringLiteral: {| Invoke: string -> bool option -> StringLiteral; Invoke: string -> bool option -> bool option -> StringLiteral |} = jsNative
```
-> Two `Invoke` Properties  
-> invalid

now: interface instead of anon record when functions/properties with same name
```fsharp
type [<AllowNullLiteral>] CreateStringLiteral =
    [<Emit("$0($1...)")>] abstract Invoke: text: string * ?isSingleQuote: bool -> StringLiteral
    [<Emit("$0($1...)")>] abstract Invoke: text: string * ?isSingleQuote: bool * ?hasExtendedUnicodeEscape: bool -> StringLiteral
```