### PR TITLE
Fail on focused (`itOnly`) test

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -110,9 +110,9 @@ module Scripts =
     /// 
     /// Requires building test before via `buildTest`
     let runTest () =
-        npx $"mocha --colors {testBuildDir}/test.js"
+        npx $"mocha --colors --forbid-only {testBuildDir}/test.js"
     let runTestWithReporter (reporter: string) =
-        npx $"mocha --reporter {reporter} {testBuildDir}/test.js"
+        npx $"mocha --reporter {reporter} --forbid-only {testBuildDir}/test.js"
 
     /// Watch `./test` in debug mode, no bundle, with sourcemaps, into `./build/test`, with entry `test.js` and run tests with mocha after each change
     let watchAndRunTest () =

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -727,7 +727,7 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
         runRegressionTest "#456-generic-call-signature"
 
     // https://github.com/fable-compiler/ts2fable/pull/457
-    itOnly "regression #457 Overload in Anonymous record" <| fun _ ->
+    it "regression #457 Overload in Anonymous record" <| fun _ ->
         runRegressionTest "#457-overload-anon-record"
 
 )?timeout(25_000)


### PR DESCRIPTION
In the last PR I forgot to remove `Only` from a test -> just that one test runs  
-> fixed in this PR

To prevent this in the future, with this PR `RunTest` fails when there are focused (`itOnly`) tests. Watching tests (`WatchAndRunTest`) still allows `itOnly`.  
-> `itOnly` still ok during development (-> watch test), but fails in full build and especially on CI