### PR TITLE
Unify indirect Enum-Case-Usage with all source Enum

### DIFF
--- a/src/bridge.fs
+++ b/src/bridge.fs
@@ -159,7 +159,7 @@ module internal Bridge =
         |> fixOverloadingOnStringParameters // fixEscapeWords must be after
         |> fixUnknownEnumCaseValue
         |> replaceDiscriminatedUnions // must be after fixUnknownEnumCaseValue
-        |> unifyUnionEnumAliases
+        |> unifyUnionAliases
         |> fixEnumReferences // must be after replaceDiscriminatedUnions
         |> fixDuplicatesInUnion // must be after replaceDiscriminatedUnions
         |> fixEscapeWords

--- a/src/read.fs
+++ b/src/read.fs
@@ -806,6 +806,7 @@ let readAliasDeclaration (checker: TypeChecker) (d: TypeAliasDeclaration): FsTyp
             FullName = fullName
             Type = tp
             TypeParameters = readTypeParameters checker d.typeParameters
+            TypeScriptDeclaration = Some <| d.``type``.getText (d.getSourceFile())
         }
         |> FsType.Alias
     match tp with

--- a/src/syntax.fs
+++ b/src/syntax.fs
@@ -247,6 +247,15 @@ type FsAlias =
         FullName: string
         Type: FsType
         TypeParameters: FsType list
+        /// TypeScript source of Alias declaration
+        /// -> can be used for comments (when less info in F# than TS)
+        ///
+        /// Note: doesn't include Alias Name, just right hand side of Alias declaration!:
+        /// ```typescript
+        /// type MyAlias = number | string
+        /// ```
+        /// -> `number | string`
+        TypeScriptDeclaration: string option
     }
 
 type FsTag =

--- a/src/ts2fable.fsproj
+++ b/src/ts2fable.fsproj
@@ -10,6 +10,7 @@
     -->
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="utils.fs" />
     <Compile Include="config.fs" />
     <Compile Include="node/fileSystem.fs" />
     <Compile Include="TypeScript.fs" />

--- a/src/utils.fs
+++ b/src/utils.fs
@@ -1,0 +1,11 @@
+[<AutoOpen>]
+module ts2fable.Utils
+
+module List =
+  let sequenceOption ls =
+    let folder ele state =
+      ele
+      |> Option.bind (fun ele ->
+        state |> Option.map (fun state -> ele::state)
+      )
+    List.foldBack folder ls (Some [])

--- a/test/fragments/regressions/#451-union-enum-sub-sets.expected.fs
+++ b/test/fragments/regressions/#451-union-enum-sub-sets.expected.fs
@@ -19,6 +19,12 @@ module Alpha =
     type AliasKind =
         RootKind
 
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// RootKind.Beta
+    /// </code>
+    /// </remarks>
     type SingleKind =
         RootKind
 
@@ -133,9 +139,13 @@ module Alpha =
     type OtherSub12Kind =
         OtherKind
 
-    // ENHANCEMENT: emit XML Comments with Original TS in mixed case too
-
-    /// Two different enums -> keep Union
+    /// <summary>Two different enums -&gt; keep Union</summary>
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// RootKind.Alpha | OtherKind.Bar
+    /// </code>
+    /// </remarks>
     type MixedKind =
         U2<RootKind, OtherKind>
 

--- a/test/fragments/regressions/#460-union-of-all-same-type.d.ts
+++ b/test/fragments/regressions/#460-union-of-all-same-type.d.ts
@@ -1,0 +1,65 @@
+export declare namespace ns {
+  enum Kind {
+    Alpha = 1,
+    Beta = 2,
+    Gamma = 3,
+    Delta = 4,
+  }
+  interface Token<TKind extends Kind> {}
+  
+  type TokenAlpha = Token<Kind.Alpha>
+  type TokenBeta = Token<Kind.Beta>
+  type TokenGamma = Token<Kind.Gamma>
+  /**
+   * Common type
+   */
+  type TokenABDirect1 = Token<Kind.Alpha> | Token<Kind.Beta>
+  type TokenABDirect2 = Token<Kind.Alpha | Kind.Beta>
+  type TokenBC1 = Token<Kind.Beta | Kind.Gamma>
+  type TokenBC2 = Token<Kind.Beta> | Token<Kind.Gamma>
+  type TokenBC = TokenBeta | TokenGamma
+  type ABCToken = TokenAlpha | TokenBC | TokenGamma
+  type ABCToken2 = TokenAlpha | TokenBC | Token<Kind.Gamma>
+  type ABCToken3 = TokenAlpha | TokenBC | Token<Kind.Gamma | Kind.Delta>
+  
+  enum Other {
+    Foo = 1,
+    Bar = 2,
+  }
+  interface OtherToken<TKind extends Other> {}
+  type OtherTokenFoo = OtherToken<Other.Foo>
+  type OtherTokenBoth = OtherTokenFoo | OtherToken<Other.Bar>
+  /**
+   * No common type
+   */
+  type MixedToken = TokenGamma | OtherTokenFoo
+  
+  interface BasicToken<TKind> {}
+  /**
+   * No common type
+   */
+  type SimpleMixedToken = TokenGamma | BasicToken<Kind.Alpha>
+  type BasicKindToken = BasicToken<Kind.Alpha> | BasicToken<Kind.Beta>
+  
+  /**
+   * Doesn't need any adjustments or comments
+   */
+  type Simple = Token<Kind>
+}
+
+export declare namespace other {
+  /**
+   * requires namespace
+   */
+  type InOther1 = ns.TokenBC | ns.Token<ns.Kind.Gamma> | ns.Token<ns.Kind.Delta | ns.Kind.Alpha>
+  /**
+   * requires namespace
+   */
+  type InOther2 = ns.Token<ns.Kind.Delta | ns.Kind.Alpha>
+
+  
+  /**
+   * Doesn't need any adjustments or comments
+   */
+  type Simple = ns.Token<ns.Kind>
+}

--- a/test/fragments/regressions/#460-union-of-all-same-type.expected.fs
+++ b/test/fragments/regressions/#460-union-of-all-same-type.expected.fs
@@ -1,0 +1,201 @@
+// ts2fable 0.0.0
+module rec ``#460-union-of-all-same-type``
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+module Ns =
+
+    type [<RequireQualifiedAccess>] Kind =
+        | Alpha = 1
+        | Beta = 2
+        | Gamma = 3
+        | Delta = 4
+
+    type [<AllowNullLiteral>] Token<'TKind when 'TKind : enum<int>> =
+        interface end
+
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// Token&lt;Kind.Alpha&gt;
+    /// </code>
+    /// </remarks>
+    type TokenAlpha =
+        Token<Kind>
+
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// Token&lt;Kind.Beta&gt;
+    /// </code>
+    /// </remarks>
+    type TokenBeta =
+        Token<Kind>
+
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// Token&lt;Kind.Gamma&gt;
+    /// </code>
+    /// </remarks>
+    type TokenGamma =
+        Token<Kind>
+
+    /// <summary>Common type</summary>
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// Token&lt;Kind.Alpha&gt; | Token&lt;Kind.Beta&gt;
+    /// </code>
+    /// </remarks>
+    type TokenABDirect1 =
+        Token<Kind>
+
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// Token&lt;Kind.Alpha | Kind.Beta&gt;
+    /// </code>
+    /// </remarks>
+    type TokenABDirect2 =
+        Token<Kind>
+
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// Token&lt;Kind.Beta | Kind.Gamma&gt;
+    /// </code>
+    /// </remarks>
+    type TokenBC1 =
+        Token<Kind>
+
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// Token&lt;Kind.Beta&gt; | Token&lt;Kind.Gamma&gt;
+    /// </code>
+    /// </remarks>
+    type TokenBC2 =
+        Token<Kind>
+
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// TokenBeta | TokenGamma
+    /// </code>
+    /// </remarks>
+    type TokenBC =
+        Token<Kind>
+
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// TokenAlpha | TokenBC | TokenGamma
+    /// </code>
+    /// </remarks>
+    type ABCToken =
+        Token<Kind>
+
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// TokenAlpha | TokenBC | Token&lt;Kind.Gamma&gt;
+    /// </code>
+    /// </remarks>
+    type ABCToken2 =
+        Token<Kind>
+
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// TokenAlpha | TokenBC | Token&lt;Kind.Gamma | Kind.Delta&gt;
+    /// </code>
+    /// </remarks>
+    type ABCToken3 =
+        Token<Kind>
+
+    type [<RequireQualifiedAccess>] Other =
+        | Foo = 1
+        | Bar = 2
+
+    type [<AllowNullLiteral>] OtherToken<'TKind when 'TKind : enum<int>> =
+        interface end
+
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// OtherToken&lt;Other.Foo&gt;
+    /// </code>
+    /// </remarks>
+    type OtherTokenFoo =
+        OtherToken<Other>
+
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// OtherTokenFoo | OtherToken&lt;Other.Bar&gt;
+    /// </code>
+    /// </remarks>
+    type OtherTokenBoth =
+        OtherToken<Other>
+
+    /// No common type
+    type MixedToken =
+        U2<TokenGamma, OtherTokenFoo>
+
+    type [<AllowNullLiteral>] BasicToken<'TKind> =
+        interface end
+
+    /// <summary>No common type</summary>
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// TokenGamma | BasicToken&lt;Kind.Alpha&gt;
+    /// </code>
+    /// </remarks>
+    type SimpleMixedToken =
+        U2<TokenGamma, BasicToken<Kind>>
+
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// BasicToken&lt;Kind.Alpha&gt; | BasicToken&lt;Kind.Beta&gt;
+    /// </code>
+    /// </remarks>
+    type BasicKindToken =
+        BasicToken<Kind>
+
+    /// Doesn't need any adjustments or comments
+    type Simple =
+        Token<Kind>
+
+module Other =
+
+    /// <summary>requires namespace</summary>
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// ns.TokenBC | ns.Token&lt;ns.Kind.Gamma&gt; | ns.Token&lt;ns.Kind.Delta | ns.Kind.Alpha&gt;
+    /// </code>
+    /// </remarks>
+    type InOther1 =
+        Ns.Token<Ns.Kind>
+
+    /// <summary>requires namespace</summary>
+    /// <remarks>
+    /// Original in TypeScript:  
+    /// <code lang="typescript">
+    /// ns.Token&lt;ns.Kind.Delta | ns.Kind.Alpha&gt;
+    /// </code>
+    /// </remarks>
+    type InOther2 =
+        Ns.Token<Ns.Kind>
+
+    /// Doesn't need any adjustments or comments
+    type Simple =
+        Ns.Token<Ns.Kind>

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -747,4 +747,8 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
     it "regression #457 Overload in Anonymous record" <| fun _ ->
         runRegressionTest "#457-overload-anon-record"
 
+    // https://github.com/fable-compiler/ts2fable/pull/460
+    it "regression #460 Union of all same type" <| fun _ ->
+        runRegressionTest "#460-union-of-all-same-type"
+
 )


### PR DESCRIPTION
Follow up(ish) to #451

```typescript
enum Kind {
    Alpha = 1,
    Beta = 2,
    Gamma = 3,
    Delta = 4,
}
interface Token<TKind extends Kind> {}

type TokenBC1 = Token<Kind.Beta | Kind.Gamma>
type TokenBC2 = Token<Kind.Beta> | Token<Kind.Gamma>

type TokenBeta = Token<Kind.Beta>
type TokenGamma = Token<Kind.Gamma>
type TokenBC3 = TokenBeta | TokenGamma
```

Currently:
```fsharp
//[...]
type TokenBC1 =
    Token<Kind>

type TokenBC2 =
    Token<Kind>

type TokenBeta =
    Token<Kind>

type TokenGamma =
    Token<Kind>

type TokenBC3 =
    U2<TokenBeta, TokenGamma>
```

-> Unlike `TokenBC1` & `2`, `TokenBC3` doesn't get reduced to `Token<Kind>`, because it doesn't directly use `Token<...>`, but instead via Alias.


With this PR `TokenBC3` gets reduced to `Token<Kind>` too:
```fsharp
type TokenBC3 =
    Token<Kind>
```

<br/>

-------------------

<br/>

Additional: If ts2fable removes Enum-Case info (like in example above: Actual Kind Case gets reduced to Kind Type), I now put a XML comment with original TS source on that alias:
```fsharp
/// <remarks>
/// Original in TypeScript:  
/// <code lang="typescript">
/// Token&lt;Kind.Beta | Kind.Gamma&gt;
/// </code>
/// </remarks>
type TokenBC1 =
    Token<Kind>

/// <remarks>
/// Original in TypeScript:  
/// <code lang="typescript">
/// Token&lt;Kind.Beta&gt; | Token&lt;Kind.Gamma&gt;
/// </code>
/// </remarks>
type TokenBC2 =
    Token<Kind>

/// <remarks>
/// Original in TypeScript:  
/// <code lang="typescript">
/// Token&lt;Kind.Beta&gt;
/// </code>
/// </remarks>
type TokenBeta =
    Token<Kind>

/// <remarks>
/// Original in TypeScript:  
/// <code lang="typescript">
/// Token&lt;Kind.Gamma&gt;
/// </code>
/// </remarks>
type TokenGamma =
    Token<Kind>

/// <remarks>
/// Original in TypeScript:  
/// <code lang="typescript">
/// TokenBeta | TokenGamma
/// </code>
/// </remarks>
type TokenBC3 =
    Token<Kind>
```

(Unfortunately only really readable in rendered comments and not in code because of escaped `<` & `>` ... because XML :/ ...)

<br/>
<br/>

Note: Remark gets only added iff there was something removed:
```typescript
type Simple = Token<Kind>
```
doesn't get a TS comment:
```fsharp
type Simple =
    Token<Kind>
```

<br/>

Note: Currently only type alias gets those remarks. Interface `Token<TKind>` doesn't get a comment despite `Kind` constraint is removed:
```fsharp
type [<AllowNullLiteral>] Token<'TKind when 'TKind : enum<int>> =
    interface end
```