### PR TITLE
Disable `enum` constraint

### DIFF
--- a/src/print.fs
+++ b/src/print.fs
@@ -195,8 +195,13 @@ let printGenericTypeConstraint (p: FsGenericTypeParameter): string option =
         let rec printConstraint =
             function
             | FsType.GenericTypeParameterEnumConstraint FsEnumCaseType.Numeric ->
-                sprintf "%s : enum<int>" p.Name
-                |> Some
+                // disable enum constraint because of https://github.com/dotnet/fsharp/issues/14580 :
+                // type alias & inheritance do not work with `enum` constraint in same rec module/namespace,
+                // but instead produce compiler error at enum decl: internal error: no 'value__' field found for enumeration type
+                // -> disable until bug fixed
+                // sprintf "%s : enum<int>" p.Name
+                // |> Some
+                None
             | FsType.GenericTypeParameterEnumConstraint _ ->
                 None
               // actual type or generic parameter name: `MyType`, `T`

--- a/test/fragments/regressions/#454-extends-enum.expected.fs
+++ b/test/fragments/regressions/#454-extends-enum.expected.fs
@@ -14,11 +14,19 @@ open Fable.Core.JS
 /// </summary>
 module N =
 
+    // `enum` constraint doesn't work in rec module and type alias or inheritance
+    // see https://github.com/dotnet/fsharp/issues/14580
+    // -> disabled until fixed
+
     type [<AllowNullLiteral>] IExports =
-        abstract fRootKind: value: 'TKind -> 'TKind when 'TKind : enum<int>
-        abstract fSub1Kind: value: 'TKind -> 'TKind when 'TKind : enum<int>
-        abstract fSubValue: value: 'TKind -> 'TKind when 'TKind : enum<int>
-        abstract fSubSet: value: 'TKind -> 'TKind when 'TKind : enum<int>
+        // abstract fRootKind: value: 'TKind -> 'TKind when 'TKind : enum<int>
+        // abstract fSub1Kind: value: 'TKind -> 'TKind when 'TKind : enum<int>
+        // abstract fSubValue: value: 'TKind -> 'TKind when 'TKind : enum<int>
+        // abstract fSubSet: value: 'TKind -> 'TKind when 'TKind : enum<int>
+        abstract fRootKind: value: 'TKind -> 'TKind
+        abstract fSub1Kind: value: 'TKind -> 'TKind
+        abstract fSubValue: value: 'TKind -> 'TKind
+        abstract fSubSet: value: 'TKind -> 'TKind
 
     type [<RequireQualifiedAccess>] RootKind =
         | Alpha = 1
@@ -35,16 +43,28 @@ module N =
     type SubKind =
         RootKind
 
-    type [<AllowNullLiteral>] InterfaceRootKind<'TKind when 'TKind : enum<int>> =
+    // type [<AllowNullLiteral>] InterfaceRootKind<'TKind when 'TKind : enum<int>> =
+    //     interface end
+
+    // type [<AllowNullLiteral>] InterfaceSubKind<'TKind when 'TKind : enum<int>> =
+    //     interface end
+
+    // type [<AllowNullLiteral>] InterfaceSubValue<'TKind when 'TKind : enum<int>> =
+    //     interface end
+
+    // type [<AllowNullLiteral>] InterfaceSubSet<'TKind when 'TKind : enum<int>> =
+    //     interface end
+
+    type [<AllowNullLiteral>] InterfaceRootKind<'TKind> =
         interface end
 
-    type [<AllowNullLiteral>] InterfaceSubKind<'TKind when 'TKind : enum<int>> =
+    type [<AllowNullLiteral>] InterfaceSubKind<'TKind> =
         interface end
 
-    type [<AllowNullLiteral>] InterfaceSubValue<'TKind when 'TKind : enum<int>> =
+    type [<AllowNullLiteral>] InterfaceSubValue<'TKind> =
         interface end
 
-    type [<AllowNullLiteral>] InterfaceSubSet<'TKind when 'TKind : enum<int>> =
+    type [<AllowNullLiteral>] InterfaceSubSet<'TKind> =
         interface end
 
 /// extends string enum

--- a/test/fragments/regressions/#460-union-of-all-same-type.expected.fs
+++ b/test/fragments/regressions/#460-union-of-all-same-type.expected.fs
@@ -16,7 +16,13 @@ module Ns =
         | Gamma = 3
         | Delta = 4
 
-    type [<AllowNullLiteral>] Token<'TKind when 'TKind : enum<int>> =
+    // `enum` constraint doesn't work in rec module and type alias or inheritance
+    // see https://github.com/dotnet/fsharp/issues/14580
+    // -> disabled until fixed
+
+    // type [<AllowNullLiteral>] Token<'TKind when 'TKind : enum<int>> =
+    //     interface end
+    type [<AllowNullLiteral>] Token<'TKind> =
         interface end
 
     /// <remarks>
@@ -123,7 +129,9 @@ module Ns =
         | Foo = 1
         | Bar = 2
 
-    type [<AllowNullLiteral>] OtherToken<'TKind when 'TKind : enum<int>> =
+    // type [<AllowNullLiteral>] OtherToken<'TKind when 'TKind : enum<int>> =
+    //     interface end
+    type [<AllowNullLiteral>] OtherToken<'TKind> =
         interface end
 
     /// <remarks>


### PR DESCRIPTION
There's a bug in FCS that produces compiler error when `enum` constraint, `rec` module, and type alias or inheritance  
see https://github.com/dotnet/fsharp/issues/14580

Solution for now is to not use `enum` constraint

Should be enabled again once bug is fixed