### PR TITLE
Handle bool,int,float Literal parameters

### DIFF
--- a/src/bridge.fs
+++ b/src/bridge.fs
@@ -156,7 +156,7 @@ module internal Bridge =
         |> fixDateTime
         |> fixStatic
         |> createIExports
-        |> fixOverloadingOnStringParameters // fixEscapeWords must be after
+        |> fixOverloadingOnLiteralParameters // fixEscapeWords must be after
         |> fixUnknownEnumCaseValue
         |> replaceDiscriminatedUnions // must be after fixUnknownEnumCaseValue
         |> unifyUnionAliases

--- a/src/syntax.fs
+++ b/src/syntax.fs
@@ -171,6 +171,7 @@ type FsParam =
 
 [<RequireQualifiedAccess>]
 module FsParam =
+    let isLiteral (p: FsParam): bool = FsType.isLiteral p.Type
     let isStringLiteral (p: FsParam): bool = FsType.isStringLiteral p.Type
 
 [<RequireQualifiedAccess>]
@@ -196,6 +197,7 @@ with
     member x.HasStringLiteralParams = x.Params |> List.exists FsParam.isStringLiteral
     member x.StringLiteralParams = x.Params |> List.filter FsParam.isStringLiteral
     member x.NonStringLiteralParams = x.Params |> List.filter (not << FsParam.isStringLiteral)
+    member x.HasLiteralParams = x.Params |> List.exists FsParam.isLiteral
 
 [<RequireQualifiedAccess>]
 type FsPropertyKind =
@@ -456,6 +458,7 @@ module FsType =
     let isMapped tp = match tp with | FsType.Mapped _ -> true | _ -> false
     let isFunction tp = match tp with | FsType.Function _ -> true | _ -> false
     let isInterface tp = match tp with | FsType.Interface _ -> true | _ -> false
+    let isLiteral tp = match tp with | FsType.Literal _ -> true | _ -> false
     let isStringLiteral tp = match tp with | FsType.Literal (FsLiteral.String _) -> true | _ -> false
     let isModule tp = match tp with | FsType.Module _ -> true | _ -> false
     let isImport tp = match tp with | FsType.Import _ -> true | _ -> false

--- a/test/fragments/regressions/#463-literal-parameters.d.ts
+++ b/test/fragments/regressions/#463-literal-parameters.d.ts
@@ -1,0 +1,39 @@
+/**
+ * `myTest1` & `myTest2` & `myTest4` should get reduced to just one `member` each
+ * 
+ * all others should be transformed to unit parameter with value in emit & name
+ */
+export declare namespace ns {
+  function myTest1(v: any): v is number
+  function myTest1(v: any): v is number | string
+
+  function myTest2(v: any, condition: false): v is number
+  function myTest2(v: any, condition: boolean): v is number | string
+
+  function myTest3(v: "hello"): false
+  function myTest3(v: "world"): true
+
+  function myTest4(v: any): false
+  function myTest4(v: any): true
+
+  function myTest5(v: "hello"): boolean
+  function myTest5(v: "world"): boolean
+
+  function myTest6(v: "hello", s: "world"): boolean
+  function myTest6(v: "world", s: "hello"): boolean
+
+  function myTest7(v: "hello"): "world"
+  function myTest7(v: "world"): "hello"
+
+  function myTest8(v: 3.14)
+  function myTest8(v: 2.72)
+  
+  function myTest9(v: 42)
+  function myTest9(v: 123)
+
+  function myTest10(v: false)
+  function myTest10(v: true)
+
+  function myTest11(a: string, b: 42, c: 123)
+  function myTest11(a: string, b: "foo", c: 3.14)
+}

--- a/test/fragments/regressions/#463-literal-parameters.expected.fs
+++ b/test/fragments/regressions/#463-literal-parameters.expected.fs
@@ -1,0 +1,38 @@
+// ts2fable 0.0.0
+module rec ``#463-literal-parameters``
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+/// <summary>
+/// <c>myTest1</c> &amp; <c>myTest2</c> &amp; <c>myTest4</c> should get reduced to just one <c>member</c> each
+/// 
+/// all others should be transformed to unit parameter with value in emit &amp; name
+/// </summary>
+module Ns =
+
+    type [<AllowNullLiteral>] IExports =
+        abstract myTest1: v: obj option -> bool
+        [<Emit("$0.myTest2($1,false)")>] abstract myTest2_false: v: obj option -> bool
+        abstract myTest2: v: obj option * condition: bool -> bool
+        [<Emit("$0.myTest3('hello')")>] abstract myTest3_hello: unit -> bool
+        [<Emit("$0.myTest3('world')")>] abstract myTest3_world: unit -> bool
+        abstract myTest4: v: obj option -> bool
+        [<Emit("$0.myTest5('hello')")>] abstract myTest5_hello: unit -> bool
+        [<Emit("$0.myTest5('world')")>] abstract myTest5_world: unit -> bool
+        [<Emit("$0.myTest6('hello','world')")>] abstract myTest6_hello_world: unit -> bool
+        [<Emit("$0.myTest6('world','hello')")>] abstract myTest6_world_hello: unit -> bool
+        [<Emit("$0.myTest7('hello')")>] abstract myTest7_hello: unit -> string
+        [<Emit("$0.myTest7('world')")>] abstract myTest7_world: unit -> string
+        [<Emit("$0.myTest8(3.14)")>] abstract ``myTest8_3.14``: unit -> unit
+        [<Emit("$0.myTest8(2.72)")>] abstract ``myTest8_2.72``: unit -> unit
+        [<Emit("$0.myTest9(42)")>] abstract myTest9_42: unit -> unit
+        [<Emit("$0.myTest9(123)")>] abstract myTest9_123: unit -> unit
+        [<Emit("$0.myTest10(false)")>] abstract myTest10_false: unit -> unit
+        [<Emit("$0.myTest10(true)")>] abstract myTest10_true: unit -> unit
+        [<Emit("$0.myTest11($1,42,123)")>] abstract myTest11_42_123: a: string -> unit
+        [<Emit("$0.myTest11($1,'foo',3.14)")>] abstract ``myTest11_foo_3.14``: a: string -> unit

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -751,4 +751,7 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
     it "regression #460 Union of all same type" <| fun _ ->
         runRegressionTest "#460-union-of-all-same-type"
 
+    // https://github.com/fable-compiler/ts2fable/pull/463
+    it "regression #463 Literal Parameters" <| fun _ ->
+        runRegressionTest "#463-literal-parameters"
 )


### PR DESCRIPTION
Currently only string literals are handled, but not bool, int, float literals:
```typescript
function myTest3(v: "hello")
function myTest8(v: 3.14)
function myTest9(v: 42)
function myTest10(v: true)
```
->
```fsharp
[<Emit("$0.myTest3('hello')")>] abstract myTest3_hello: unit -> unit
abstract myTest8: v: float -> unit
abstract myTest9: v: int -> unit
abstract myTest9: v: bool -> unit
```

With this PR float, int, and bool literals are now emitted too:
```fsharp
[<Emit("$0.myTest3('hello')")>] abstract myTest3_hello: unit -> unit
[<Emit("$0.myTest8(3.14)")>] abstract ``myTest8_3.14``: unit -> unit
[<Emit("$0.myTest9(42)")>] abstract myTest9_42: unit -> unit
[<Emit("$0.myTest10(true)")>] abstract myTest10_true: unit -> unit
```