### PR TITLE
Fix: Duplicated Method in generated Interface when TS has duplicated method

### DIFF
--- a/src/bridge.fs
+++ b/src/bridge.fs
@@ -168,9 +168,9 @@ module internal Bridge =
         |> addTicForGenericTypes
         // |> removeTodoMembers
         |> removeTypeParamsFromStatic
-        |> removeDuplicateFunctions
         |> removeDuplicateOptions
         |> extractTypeLiterals // after fixEscapeWords
+        |> removeDuplicateFunctions
         |> removeDuplicateOptionsFromParameters
         |> fixFloatAlias
         |> TransformComments.transform

--- a/test/fragments/regressions/#464-duplicated-method-in-generated-interface.d.ts
+++ b/test/fragments/regressions/#464-duplicated-method-in-generated-interface.d.ts
@@ -3,4 +3,13 @@ export declare namespace ns {
     (arg: string): boolean
     (arg: string): boolean
   }
+
+  /**
+   * Source: https://github.com/microsoft/TypeScript/blob/e2868216f637e875a74c675845625eb15dcfe9a2/lib/typescript.d.ts#L7232-L7236
+   */
+  const createImportTypeNode: {
+      (argument: TypeNode, assertions?: ImportTypeAssertionContainer | undefined, qualifier?: EntityName | undefined, typeArguments?: readonly TypeNode[] | undefined, isTypeOf?: boolean | undefined): ImportTypeNode;
+      (argument: TypeNode, assertions?: ImportTypeAssertionContainer | undefined, qualifier?: EntityName | undefined, typeArguments?: readonly TypeNode[] | undefined, isTypeOf?: boolean | undefined): ImportTypeNode;
+      (argument: TypeNode, qualifier?: EntityName | undefined, typeArguments?: readonly TypeNode[] | undefined, isTypeOf?: boolean | undefined): ImportTypeNode;
+  };
 }

--- a/test/fragments/regressions/#464-duplicated-method-in-generated-interface.d.ts
+++ b/test/fragments/regressions/#464-duplicated-method-in-generated-interface.d.ts
@@ -1,0 +1,6 @@
+export declare namespace ns {
+  const node: {
+    (arg: string): boolean
+    (arg: string): boolean
+  }
+}

--- a/test/fragments/regressions/#464-duplicated-method-in-generated-interface.expected.fs
+++ b/test/fragments/regressions/#464-duplicated-method-in-generated-interface.expected.fs
@@ -1,5 +1,8 @@
 // ts2fable 0.0.0
 module rec ``#464-duplicated-method-in-generated-interface``
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
 open System
 open Fable.Core
 open Fable.Core.JS
@@ -9,6 +12,12 @@ module Ns =
 
     type [<AllowNullLiteral>] IExports =
         abstract node: IExportsNode
+        /// <summary>Source: <see href="https://github.com/microsoft/TypeScript/blob/e2868216f637e875a74c675845625eb15dcfe9a2/lib/typescript.d.ts#L7232-L7236" /></summary>
+        abstract createImportTypeNode: IExportsCreateImportTypeNode
 
     type [<AllowNullLiteral>] IExportsNode =
         [<Emit("$0($1...)")>] abstract Invoke: arg: string -> bool
+
+    type [<AllowNullLiteral>] IExportsCreateImportTypeNode =
+        [<Emit("$0($1...)")>] abstract Invoke: argument: TypeNode * ?assertions: ImportTypeAssertionContainer * ?qualifier: EntityName * ?typeArguments: ResizeArray<TypeNode> * ?isTypeOf: bool -> ImportTypeNode
+        [<Emit("$0($1...)")>] abstract Invoke: argument: TypeNode * ?qualifier: EntityName * ?typeArguments: ResizeArray<TypeNode> * ?isTypeOf: bool -> ImportTypeNode

--- a/test/fragments/regressions/#464-duplicated-method-in-generated-interface.expected.fs
+++ b/test/fragments/regressions/#464-duplicated-method-in-generated-interface.expected.fs
@@ -1,0 +1,14 @@
+// ts2fable 0.0.0
+module rec ``#464-duplicated-method-in-generated-interface``
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+module Ns =
+
+    type [<AllowNullLiteral>] IExports =
+        abstract node: IExportsNode
+
+    type [<AllowNullLiteral>] IExportsNode =
+        [<Emit("$0($1...)")>] abstract Invoke: arg: string -> bool

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -754,4 +754,8 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
     // https://github.com/fable-compiler/ts2fable/pull/463
     it "regression #463 Literal Parameters" <| fun _ ->
         runRegressionTest "#463-literal-parameters"
+
+    // https://github.com/fable-compiler/ts3fable/pull/464
+    it "regression #464 duplicated method in generated interface" <| fun _ ->
+        runRegressionTest "#464-duplicated-method-in-generated-interface"
 )


### PR DESCRIPTION
```typescript
const node: {
  (arg: string): boolean
  (arg: string): boolean
}
```
currently produces:
```fsharp
type [<AllowNullLiteral>] IExportsNode =
    [<Emit("$0($1...)")>] abstract Invoke: arg: string -> bool
    [<Emit("$0($1...)")>] abstract Invoke: arg: string -> bool
```
-> error:
> Duplicate method. The method 'Invoke' has the same name and signature as another method in type '[...].IExportsNode'.


In other cases duplicated methods already get reduced -- but here that didn't happen