### PR TITLE
Add Option to remove `Obsolete` Functions, Properties, Variables

### DIFF
--- a/src/bridge.fs
+++ b/src/bridge.fs
@@ -139,6 +139,10 @@ module internal Bridge =
         // |> log "start"
         // |> wrapperModuleForExtralFile
         |> removeInternalModules
+           // should be early:
+           // * prevent creation of helper interfaces that might remain
+           // * throw away stuff that doesn't need handling -> faster
+        |> if Config.RemoveObsolete then removeObsolete else id
         |> mergeModulesInFile
         |> aliasToInterfacePartly
         |> removeKeyOfConstraint

--- a/src/config.fs
+++ b/src/config.fs
@@ -3,16 +3,19 @@ module Config
 let mutable EmitResizeArray = true
 let mutable ConvertPropertyFunctions = false
 let mutable TaggedUnion = false
+let mutable RemoveObsolete = false
 
 let Reset() =
     EmitResizeArray <- true
     ConvertPropertyFunctions <- false
     TaggedUnion <- false
+    RemoveObsolete <- false
 
 module OptionNames =
     let NoEmitResizeArray = "--noresizearray"
     let ConvertPropertyFunctions = "--convertpropfns"
     let TaggedUnion = "--tagged-union"
+    let RemoveObsolete = "--remove-obsolete"
     let Exports = "--export"
     let Help = "--help"
     let Version = "--version"
@@ -31,6 +34,9 @@ let Options =
         (OptionNames.TaggedUnion,
          "Detect discriminated unions and convert them to [<TypeScriptTaggedUnion>]")
 
+        (OptionNames.RemoveObsolete,
+         "Remove @deprecated/Obsolete elements if possible")
+
         (OptionNames.Version,
          "Show tool version" )
 
@@ -43,3 +49,10 @@ let Usage() =
     Options
         |> List.map (fun (opt,desc) -> sprintf "%-20s %s\n" opt desc)
         |> List.fold (+) ""
+
+let setFromArgs(args: string[]) =
+    EmitResizeArray <- not (args |> Array.contains (OptionNames.NoEmitResizeArray))
+    ConvertPropertyFunctions <- args |> Array.contains (OptionNames.ConvertPropertyFunctions)
+    TaggedUnion <- args |> Array.contains (OptionNames.TaggedUnion)
+    RemoveObsolete <- args |> Array.contains (OptionNames.RemoveObsolete)
+    ()

--- a/src/ts2fable.fs
+++ b/src/ts2fable.fs
@@ -15,9 +15,7 @@ let parseArgs (args: string[]) =
     let exports = args |> getArgs (fun s -> s = "-e" || s = "--exports")
     let fsPaths = args |> Array.filter (fun s -> s.EndsWith ".fs") |> Array.toList
     let tsPaths = args |> Array.filter (fun s -> s.EndsWith ".ts") |> Array.toList
-    Config.EmitResizeArray <- not (args |> Array.contains (Config.OptionNames.NoEmitResizeArray))
-    Config.ConvertPropertyFunctions <- args |> Array.contains (Config.OptionNames.ConvertPropertyFunctions)
-    Config.TaggedUnion <- args |> Array.contains (Config.OptionNames.TaggedUnion)
+    Config.setFromArgs args
     if List.isEmpty fsPaths then failwithf "Please provide the path to the F# file to be written."
     if List.isEmpty tsPaths then failwithf "Please provide the path to a TypeScript file."
     // print ts2fable version

--- a/test/fragments/custom/obsolete/dont-remove-obsolete.d.ts
+++ b/test/fragments/custom/obsolete/dont-remove-obsolete.d.ts
@@ -1,0 +1,99 @@
+// Same as `remove-obsolete.d.ts`, but without `--remove-obsolete`
+// -> all deprecated/obsolete should remain!
+
+// Note: auto-copied from `remove-obsolete.d.ts`
+// -> edit `remove-obsolete.d.ts` instead of this file here!
+
+/**
+ * ns should stay
+ */
+declare namespace ns {
+    /**
+     * remove
+     * 
+     * @deprecated reason
+     */
+    function doStuff(v: number): boolean;
+    /**
+     * Not obsolete -> `I` MUST stay
+     */
+    interface I {
+        /**
+         * remove
+         * 
+         * @deprecated reason
+         */
+        doStuff(v: number): boolean;
+        /**
+         * remove
+         * 
+         * @deprecated reason
+         */
+        value: number;
+    }
+
+    
+    /**
+     * Should not stay: deprecated, and not used
+     * 
+     * @deprecated reason
+     */
+    interface UnusedInterface {}
+
+    /**
+     * Should stay: deprecated, but used in function
+     * 
+     * @deprecated reason
+     */
+    interface UsedInterface {}
+    function onUsedClass(uc: UsedInterface): void
+
+    /**
+     * Should not stay: deprecated, and used in deprecated function
+     * 
+     * @deprecated reason
+     */
+    interface UsedInOtherDeprecatedInterface {}
+    function onUsedInOtherDeprecatedClass(uc: UsedInOtherDeprecatedInterface): void
+
+    /**
+     * remove
+     * 
+     * @deprecated reason
+     */
+    const myValue: number
+
+    /**
+     * `J` and anything inside `J` should be removed
+     * 
+     * @deprecated reason
+     */
+    interface J {
+        doStuff(v: number): boolean
+        value: number
+    }
+}
+/**
+ * remove
+ * 
+ * @deprecated reason
+ */
+declare function doStuff(v: number): boolean
+
+/**
+ * remove
+ * 
+ * @deprecated reason
+ */
+declare const myValue = 42
+
+/**
+ * `nsd` and everything inside should be removed!
+ * 
+ * @deprecated reason
+ */
+declare namespace nsd {
+    const myValue: number
+    function f(v: any): void
+}
+

--- a/test/fragments/custom/obsolete/dont-remove-obsolete.expected.fs
+++ b/test/fragments/custom/obsolete/dont-remove-obsolete.expected.fs
@@ -1,0 +1,70 @@
+// ts2fable 0.0.0
+module rec ``dont-remove-obsolete``
+
+#nowarn "3390" // disable warnings for invalid XML comments
+#nowarn "0044" // disable warnings for `Obsolete` usage
+
+open System
+open Fable.Core
+open Fable.Core.JS
+
+/// remove
+[<Obsolete("reason")>]
+let [<Import("myValue","dont-remove-obsolete")>] myValue: obj = jsNative
+
+type [<AllowNullLiteral>] IExports =
+    /// remove
+    [<Obsolete("reason")>]
+    abstract doStuff: v: float -> bool
+
+/// ns should stay
+module Ns =
+
+    type [<AllowNullLiteral>] IExports =
+        /// remove
+        [<Obsolete("reason")>]
+        abstract doStuff: v: float -> bool
+        abstract onUsedClass: uc: UsedInterface -> unit
+        abstract onUsedInOtherDeprecatedClass: uc: UsedInOtherDeprecatedInterface -> unit
+        /// remove
+        [<Obsolete("reason")>]
+        abstract myValue: float
+
+    /// <summary>Not obsolete -&gt; <c>I</c> MUST stay</summary>
+    type [<AllowNullLiteral>] I =
+        /// remove
+        [<Obsolete("reason")>]
+        abstract doStuff: v: float -> bool
+        /// remove
+        [<Obsolete("reason")>]
+        abstract value: float with get, set
+
+    /// Should not stay: deprecated, and not used
+    [<Obsolete("reason")>]
+    type [<AllowNullLiteral>] UnusedInterface =
+        interface end
+
+    /// Should stay: deprecated, but used in function
+    [<Obsolete("reason")>]
+    type [<AllowNullLiteral>] UsedInterface =
+        interface end
+
+    /// Should not stay: deprecated, and used in deprecated function
+    [<Obsolete("reason")>]
+    type [<AllowNullLiteral>] UsedInOtherDeprecatedInterface =
+        interface end
+
+    /// <summary><c>J</c> and anything inside <c>J</c> should be removed</summary>
+    [<Obsolete("reason")>]
+    type [<AllowNullLiteral>] J =
+        abstract doStuff: v: float -> bool
+        abstract value: float with get, set
+
+/// <summary><c>nsd</c> and everything inside should be removed!</summary>
+[<Obsolete("reason")>]
+module Nsd =
+
+    type [<AllowNullLiteral>] IExports =
+        abstract myValue: float
+        abstract f: v: obj option -> unit
+

--- a/test/fragments/custom/obsolete/remove-obsolete.d.ts
+++ b/test/fragments/custom/obsolete/remove-obsolete.d.ts
@@ -1,0 +1,101 @@
+//--remove-obsolete
+
+// Note: Currently only functions, properties, variables get removed
+//   Reason: Other Elements might be referenced somewhere, while functions, properties, variables cannot.
+//      -> for other elements it's way harder to correctly detect if they can or cannot be removed
+
+// below: split marker for copy to `dont-remove-obsolete.d.ts` -> marker and above gets removed
+// ------------ 
+
+/**
+ * ns should stay
+ */
+declare namespace ns {
+    /**
+     * remove
+     * 
+     * @deprecated reason
+     */
+    function doStuff(v: number): boolean;
+    /**
+     * Not obsolete -> `I` MUST stay
+     */
+    interface I {
+        /**
+         * remove
+         * 
+         * @deprecated reason
+         */
+        doStuff(v: number): boolean;
+        /**
+         * remove
+         * 
+         * @deprecated reason
+         */
+        value: number;
+    }
+
+    
+    /**
+     * Should not stay: deprecated, and not used
+     * 
+     * @deprecated reason
+     */
+    interface UnusedInterface {}
+
+    /**
+     * Should stay: deprecated, but used in function
+     * 
+     * @deprecated reason
+     */
+    interface UsedInterface {}
+    function onUsedClass(uc: UsedInterface): void
+
+    /**
+     * Should not stay: deprecated, and used in deprecated function
+     * 
+     * @deprecated reason
+     */
+    interface UsedInOtherDeprecatedInterface {}
+    function onUsedInOtherDeprecatedClass(uc: UsedInOtherDeprecatedInterface): void
+
+    /**
+     * remove
+     * 
+     * @deprecated reason
+     */
+    const myValue: number
+
+    /**
+     * `J` and anything inside `J` should be removed
+     * 
+     * @deprecated reason
+     */
+    interface J {
+        doStuff(v: number): boolean
+        value: number
+    }
+}
+/**
+ * remove
+ * 
+ * @deprecated reason
+ */
+declare function doStuff(v: number): boolean
+
+/**
+ * remove
+ * 
+ * @deprecated reason
+ */
+declare const myValue = 42
+
+/**
+ * `nsd` and everything inside should be removed!
+ * 
+ * @deprecated reason
+ */
+declare namespace nsd {
+    const myValue: number
+    function f(v: any): void
+}

--- a/test/fragments/custom/obsolete/remove-obsolete.expected.fs
+++ b/test/fragments/custom/obsolete/remove-obsolete.expected.fs
@@ -1,0 +1,50 @@
+// ts2fable 0.0.0
+module rec ``remove-obsolete``
+
+#nowarn "3390" // disable warnings for invalid XML comments
+#nowarn "0044" // disable warnings for `Obsolete` usage
+
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+/// ns should stay
+module Ns =
+
+    type [<AllowNullLiteral>] IExports =
+        abstract onUsedClass: uc: UsedInterface -> unit
+        abstract onUsedInOtherDeprecatedClass: uc: UsedInOtherDeprecatedInterface -> unit
+
+    /// <summary>Not obsolete -&gt; <c>I</c> MUST stay</summary>
+    type [<AllowNullLiteral>] I =
+        interface end
+
+    /// Should not stay: deprecated, and not used
+    [<Obsolete("reason")>]
+    type [<AllowNullLiteral>] UnusedInterface =
+        interface end
+
+    /// Should stay: deprecated, but used in function
+    [<Obsolete("reason")>]
+    type [<AllowNullLiteral>] UsedInterface =
+        interface end
+
+    /// Should not stay: deprecated, and used in deprecated function
+    [<Obsolete("reason")>]
+    type [<AllowNullLiteral>] UsedInOtherDeprecatedInterface =
+        interface end
+
+    /// <summary><c>J</c> and anything inside <c>J</c> should be removed</summary>
+    [<Obsolete("reason")>]
+    type [<AllowNullLiteral>] J =
+        abstract doStuff: v: float -> bool
+        abstract value: float with get, set
+
+/// <summary><c>nsd</c> and everything inside should be removed!</summary>
+[<Obsolete("reason")>]
+module Nsd =
+
+    type [<AllowNullLiteral>] IExports =
+        abstract myValue: float
+        abstract f: v: obj option -> unit

--- a/web-app/App.fs
+++ b/web-app/App.fs
@@ -25,7 +25,8 @@ type Msg =
     | UpdateFSharpCode
     | ToggleConfigEmitResizeArray
     | ToggleConfigConvertPropertyFunctions
-    | ToggleTaggedUnion
+    | ToggleConfigTaggedUnion
+    | ToggleConfigRemoveObsolete
 
 let ts2fable s =
     printfn "// Placeholder for ts2fable lib\n"
@@ -60,8 +61,12 @@ let update msg model =
         Config.ConvertPropertyFunctions <- not (Config.ConvertPropertyFunctions)
         model, Cmd.ofMsg UpdateFSharpCode
 
-    | ToggleTaggedUnion ->
+    | ToggleConfigTaggedUnion ->
         Config.TaggedUnion <- not (Config.TaggedUnion)
+        model, Cmd.ofMsg UpdateFSharpCode
+
+    | ToggleConfigRemoveObsolete ->
+        Config.RemoveObsolete <- not (Config.RemoveObsolete)
         model, Cmd.ofMsg UpdateFSharpCode
 
 open Fable.React
@@ -126,7 +131,8 @@ let private navbar model dispatch =
                 [ strong [ ]
                     [ str "ts2fable" ] ] ]
           Navbar.Start.div [ ]
-            [ Navbar.Item.div [ Navbar.Item.HasDropdown
+            [ 
+              Navbar.Item.div [ Navbar.Item.HasDropdown
                                 Navbar.Item.IsHoverable ]
                 [ Navbar.Link.a [ ]
                     [ str "Samples" ]
@@ -162,11 +168,20 @@ let private navbar model dispatch =
                     input [
                         Type "checkbox"
                         Checked (Config.TaggedUnion)
-                        OnChange (fun e -> dispatch ToggleTaggedUnion)
+                        OnChange (fun e -> dispatch ToggleConfigTaggedUnion)
                         ]
                   ]
               ]
-
+              Navbar.Item.div [] [
+                  span [ Title (Config.Options |> List.find (fun (n, _) -> n = Config.OptionNames.RemoveObsolete) |> snd) ] [
+                    span [] [ str (Config.OptionNames.RemoveObsolete) ]
+                    input [
+                        Type "checkbox"
+                        Checked (Config.RemoveObsolete)
+                        OnChange (fun e -> dispatch ToggleConfigRemoveObsolete)
+                        ]
+                  ]
+              ]
             ]
           Navbar.End.div [ ]
             [ Navbar.Item.div [ ]


### PR DESCRIPTION
Elements annotated with `@deprecated` get marked with `[<Obsolete(...)>]` in F#.  
But sometimes it's easier to handle a smaller F# file while ignoring all deprecated/obsolete elements.

This PR adds `--remove-obsolete` option to remove `Obsolete` elements.

Unfortunately that's not that trivial: Elements might reference `@deprecated` elements -> requires usage analysis.  
I currently don't do this, but instead remove only `Obsolete` elements that cannot be referenced: Functions, Properties and Variables. But not other elements like Interfaces, Aliases, Modules (-> still in output F# code and marked with `Obsolete`)


<br/>
<br/>

------------------

<br/>
<br/>


Note: (just in case somebody stumbles across it -- happens in new test files)  
`Obsolete` (with `System` open) (or any Attribute) on module inside `rec` module is buggy and produces compiler error: https://github.com/dotnet/fsharp/issues/7931  
```fsharp
module rec Root
open System

// error: The type 'Obsolete' is not defined.
[<Obsolete>]
module A = ()

// ok
[<System.Obsolete>]
module B = ()
```

ts2fable always spits out the first case (`Obsolete` without namespace).  
As it's probably not that common, easy to fix by hand, and a compiler error (though marked as "Not Planned"?...), I don't think we have to add special handling and just keep it the way it is.