### PR TITLE
Fix: Default of Generic Type Param that references other defaulted type param keeps source Type param

### DIFF
--- a/test/fragments/regressions/#466-generic-type-param-default-refs-other-type-param.d.ts
+++ b/test/fragments/regressions/#466-generic-type-param-default-refs-other-type-param.d.ts
@@ -1,0 +1,25 @@
+export interface Node {
+  readonly kind: string
+  //...
+}
+export type VisitResult<T extends Node | undefined> = T | readonly Node[]
+/**
+ * in F#: 3 `Visitor`s: with 2 generic type params, with 1 type param, without type param
+ */
+export type Visitor<TIn extends Node = Node, TOut extends Node | undefined = TIn | undefined> = (node: TIn) => VisitResult<TOut>;
+
+export interface W<T> {}
+export interface A<TA extends Node = Node, TB extends W<TA> = W<TA>> {}
+/**
+ * Note: This isn't valid in F#: `'TB :> 'TA` is not allowed!:
+ * ```fsharp
+ * type E<'TA, 'TB when 'TA :> Node and 'TB :> 'TA> = interface end
+ * //                                   ^^^^^^^^^^ Invalid constraint: the type used for the constraint is sealed, which means the constraint could only be satisfied by at most one solution
+ * //                                   ^^^^^^^^^^ This construct causes code to be less generic than indicated by the type annotations. The type variable 'TB has been constrained to be type ''TA'.
+ * //          ^^^ This type parameter has been used in a way that constrains it to always be '#Node'
+ * ```
+ */
+export interface B<TA extends Node = Node, TB extends TA = TA> {}
+
+export interface C<TA extends Node = Node, TB extends W<TA> = W<TA>, TC extends W<TB> = W<TB>, TD extends W<TB> = W<TB>> {}
+export interface D<TA extends Node = Node, TB extends TA[] = TA[], TC extends W<TB> | undefined = W<TB>> {}

--- a/test/fragments/regressions/#466-generic-type-param-default-refs-other-type-param.expected.fs
+++ b/test/fragments/regressions/#466-generic-type-param-default-refs-other-type-param.expected.fs
@@ -1,0 +1,103 @@
+// ts2fable 0.0.0
+module rec ``#466-generic-type-param-default-refs-other-type-param``
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+type [<AllowNullLiteral>] Node =
+    abstract kind: string
+
+type VisitResult<'T> =
+    U2<'T, ResizeArray<Node>>
+
+/// <summary>in F#: 3 <c>Visitor</c>s: with 2 generic type params, with 1 type param, without type param</summary>
+type Visitor =
+    Visitor<Node, Node option>
+
+/// <summary>in F#: 3 <c>Visitor</c>s: with 2 generic type params, with 1 type param, without type param</summary>
+type Visitor<'TIn when 'TIn :> Node> =
+    Visitor<'TIn, 'TIn option>
+
+/// <summary>in F#: 3 <c>Visitor</c>s: with 2 generic type params, with 1 type param, without type param</summary>
+type [<AllowNullLiteral>] Visitor<'TIn, 'TOut when 'TIn :> Node> =
+    /// <summary>in F#: 3 <c>Visitor</c>s: with 2 generic type params, with 1 type param, without type param</summary>
+    [<Emit("$0($1...)")>] abstract Invoke: node: 'TIn -> VisitResult<'TOut>
+
+type [<AllowNullLiteral>] W<'T> =
+    interface end
+
+type A =
+    A<Node, W<Node>>
+
+type A<'TA when 'TA :> Node> =
+    A<'TA, W<'TA>>
+
+type [<AllowNullLiteral>] A<'TA, 'TB when 'TA :> Node and 'TB :> W<'TA>> =
+    interface end
+
+/// <summary>
+/// Note: This isn't valid in F#: <c>'TB :&gt; 'TA</c> is not allowed!:
+/// <code lang="fsharp">
+/// type E&lt;'TA, 'TB when 'TA :&gt; Node and 'TB :&gt; 'TA&gt; = interface end
+/// //                                   ^^^^^^^^^^ Invalid constraint: the type used for the constraint is sealed, which means the constraint could only be satisfied by at most one solution
+/// //                                   ^^^^^^^^^^ This construct causes code to be less generic than indicated by the type annotations. The type variable 'TB has been constrained to be type ''TA'.
+/// //          ^^^ This type parameter has been used in a way that constrains it to always be '#Node'
+/// </code>
+/// </summary>
+type B =
+    B<Node, Node>
+
+/// <summary>
+/// Note: This isn't valid in F#: <c>'TB :&gt; 'TA</c> is not allowed!:
+/// <code lang="fsharp">
+/// type E&lt;'TA, 'TB when 'TA :&gt; Node and 'TB :&gt; 'TA&gt; = interface end
+/// //                                   ^^^^^^^^^^ Invalid constraint: the type used for the constraint is sealed, which means the constraint could only be satisfied by at most one solution
+/// //                                   ^^^^^^^^^^ This construct causes code to be less generic than indicated by the type annotations. The type variable 'TB has been constrained to be type ''TA'.
+/// //          ^^^ This type parameter has been used in a way that constrains it to always be '#Node'
+/// </code>
+/// </summary>
+type B<'TA when 'TA :> Node> =
+    B<'TA, 'TA>
+
+/// <summary>
+/// Note: This isn't valid in F#: <c>'TB :&gt; 'TA</c> is not allowed!:
+/// <code lang="fsharp">
+/// type E&lt;'TA, 'TB when 'TA :&gt; Node and 'TB :&gt; 'TA&gt; = interface end
+/// //                                   ^^^^^^^^^^ Invalid constraint: the type used for the constraint is sealed, which means the constraint could only be satisfied by at most one solution
+/// //                                   ^^^^^^^^^^ This construct causes code to be less generic than indicated by the type annotations. The type variable 'TB has been constrained to be type ''TA'.
+/// //          ^^^ This type parameter has been used in a way that constrains it to always be '#Node'
+/// </code>
+/// </summary>
+type [<AllowNullLiteral>] B<'TA, 'TB when 'TA :> Node and 'TB :> 'TA> =
+    interface end
+
+type C =
+    C<Node, W<Node>, W<W<Node>>, W<W<Node>>>
+
+type C<'TA when 'TA :> Node> =
+    C<'TA, W<'TA>, W<W<'TA>>, W<W<'TA>>>
+
+type C<'TA, 'TB when 'TA :> Node and 'TB :> W<'TA>> =
+    C<'TA, 'TB, W<'TB>, W<'TB>>
+
+type C<'TA, 'TB, 'TC when 'TA :> Node and 'TB :> W<'TA> and 'TC :> W<'TB>> =
+    C<'TA, 'TB, 'TC, W<'TB>>
+
+type [<AllowNullLiteral>] C<'TA, 'TB, 'TC, 'TD when 'TA :> Node and 'TB :> W<'TA> and 'TC :> W<'TB> and 'TD :> W<'TB>> =
+    interface end
+
+type D =
+    D<Node, ResizeArray<Node>, W<ResizeArray<Node>>>
+
+type D<'TA when 'TA :> Node> =
+    D<'TA, ResizeArray<'TA>, W<ResizeArray<'TA>>>
+
+type D<'TA, 'TB when 'TA :> Node> =
+    D<'TA, 'TB, W<'TB>>
+
+type [<AllowNullLiteral>] D<'TA, 'TB, 'TC when 'TA :> Node> =
+    interface end

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -807,4 +807,8 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
     // https://github.com/fable-compiler/ts3fable/pull/464
     it "regression #464 duplicated method in generated interface" <| fun _ ->
         runRegressionTest "#464-duplicated-method-in-generated-interface"
+
+    // https://github.com/fable-compiler/ts4fable/pull/464
+    it "regression #466 default of generic type param references other type param" <| fun _ ->
+        runRegressionTest "#466-generic-type-param-default-refs-other-type-param"
 )


### PR DESCRIPTION
```typescript
interface D<TA extends Node = Node, TB extends W<TA> = W<TA>> {}
```
Currently:
```fsharp
type D =
    D<Node, W<TA>>

type D<'TA when 'TA :> Node> =
    D<'TA, W<'TA>>

type [<AllowNullLiteral>] D<'TA, 'TB when 'TA :> Node and 'TB :> W<'TA>> =
    interface end
```
-> First `D` still uses `'TA`. But that gen type param doesn't exist. Instead `TA` is now type...


With this PR:
```fsharp
type D =
    D<Node, W<Node>>
```