### PR TITLE
Fix: TS utility Type `NonNullable` still in F# code

### DIFF
--- a/src/bridge.fs
+++ b/src/bridge.fs
@@ -144,6 +144,7 @@ module internal Bridge =
            // * throw away stuff that doesn't need handling -> faster
         |> if Config.RemoveObsolete then removeObsolete else id
         |> mergeModulesInFile
+        |> fixNonNullableType
         |> aliasToInterfacePartly
         |> removeKeyOfConstraint
         |> extractGenericParameterDefaults

--- a/test/fragments/regressions/#467-NonNullable.d.ts
+++ b/test/fragments/regressions/#467-NonNullable.d.ts
@@ -1,0 +1,36 @@
+type W<T> = { readonly value: T }
+
+/**
+ * https://www.typescriptlang.org/docs/handbook/utility-types.html#nonnullabletype
+ */
+export namespace NsNonNullable {
+  /**
+   * string | number
+   */
+  type T0 = NonNullable<string | number | undefined>;
+  /**
+   * string[]
+   */
+  type T1 = NonNullable<string[] | null | undefined>;
+
+  /**
+   * W<T>
+   */
+  type T2<T> = W<NonNullable<T>>
+
+  /**
+   * W<T> -> W<T>
+   */
+  function f0<T>(v: W<NonNullable<T>>): W<NonNullable<T>>
+  /**
+   * W<T> -> W<T>
+   */
+  function f1<T>(v: NonNullable<W<T>>): NonNullable<W<T>>
+
+  interface I0 {
+    /**
+     * W<T> -> W<T>
+     */
+    <T>(v: W<NonNullable<T>>): W<NonNullable<T>>
+  }
+}

--- a/test/fragments/regressions/#467-NonNullable.expected.fs
+++ b/test/fragments/regressions/#467-NonNullable.expected.fs
@@ -1,0 +1,39 @@
+// ts2fable 0.0.0
+module rec ``#467-NonNullable``
+
+#nowarn "3390" // disable warnings for invalid XML comments
+
+open System
+open Fable.Core
+open Fable.Core.JS
+
+/// <summary><see href="https://www.typescriptlang.org/docs/handbook/utility-types.html#nonnullabletype" /></summary>
+let [<Import("NsNonNullable","#467-NonNullable")>] nsNonNullable: NsNonNullable.IExports = jsNative
+
+type [<AllowNullLiteral>] W<'T> =
+    abstract value: 'T
+
+/// <summary><see href="https://www.typescriptlang.org/docs/handbook/utility-types.html#nonnullabletype" /></summary>
+module NsNonNullable =
+
+    type [<AllowNullLiteral>] IExports =
+        /// W<T> -> W<T>
+        abstract f0: v: W<'T> -> W<'T>
+        /// W<T> -> W<T>
+        abstract f1: v: W<'T> -> W<'T>
+
+    /// string | number
+    type T0 =
+        U2<string, float>
+
+    /// string[]
+    type T1 =
+        ResizeArray<string>
+
+    /// W<T>
+    type T2<'T> =
+        W<'T>
+
+    type [<AllowNullLiteral>] I0 =
+        /// W<T> -> W<T>
+        [<Emit("$0($1...)")>] abstract Invoke: v: W<'T> -> W<'T>

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -808,7 +808,11 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
     it "regression #464 duplicated method in generated interface" <| fun _ ->
         runRegressionTest "#464-duplicated-method-in-generated-interface"
 
-    // https://github.com/fable-compiler/ts4fable/pull/464
+    // https://github.com/fable-compiler/ts4fable/pull/466
     it "regression #466 default of generic type param references other type param" <| fun _ ->
         runRegressionTest "#466-generic-type-param-default-refs-other-type-param"
+
+    // https://github.com/fable-compiler/ts4fable/pull/467
+    it "regression #467 NonNullable" <| fun _ ->
+        runRegressionTest "#467-NonNullable"
 )


### PR DESCRIPTION
```typescript
type T1 = NonNullable<string | null | undefined>;
```
Currently:
```fsharp
type T1 = NonNullable<string option>
```

With this PR:
```fsharp
type T1 = string
```

<br/>

Note: Might lead to info getting lost:
```typescript
type T2<T> = W<NonNullable<T>>
```
->
```fsharp
type T2<'T> = W<'T>
```
-> info that `T` must be `NonNullable` gets lost  
Still best we can do in F#. And `null` outside of `option` isn't that common in F#/Fable -> should be ok




<br/>
<br/>

------------

<br/>
<br/>

Note: Besides `NonNullable`, there are [other utility types](https://www.typescriptlang.org/docs/handbook/utility-types.html) in TS. I only handle `NonNullable`. All other utility types stay in F# code.
