### PR TITLE
Fix: Slightly different string enum cases might translate to same F# case name

### DIFF
--- a/test/fragments/regressions/#468-string-enum-duplicate-fsharp-name.d.ts
+++ b/test/fragments/regressions/#468-string-enum-duplicate-fsharp-name.d.ts
@@ -1,0 +1,23 @@
+/**
+ * Keep 1st case
+ */
+export type A =
+  | "utf8"
+  | "utf-8"
+
+/**
+ * Keep 2nd case
+ */
+export type B =
+  | "utf-8"
+  | "utf8"
+
+export type C =
+  | "utf8"
+  | "Utf8"
+  | "UTF8"
+  | "utf-8"
+  | "UTF-8"
+
+
+export type BufferEncoding = "ascii" | "utf8" | "utf-8" | "utf16le" | "ucs2" | "ucs-2" | "base64" | "latin1" | "binary" | "hex";

--- a/test/fragments/regressions/#468-string-enum-duplicate-fsharp-name.expected.fs
+++ b/test/fragments/regressions/#468-string-enum-duplicate-fsharp-name.expected.fs
@@ -1,0 +1,35 @@
+// ts2fable 0.0.0
+module rec ``#468-string-enum-duplicate-fsharp-name``
+open System
+open Fable.Core
+open Fable.Core.JS
+
+
+/// Keep 1st case
+type [<StringEnum>] [<RequireQualifiedAccess>] A =
+    | Utf8
+    | [<CompiledName("utf-8")>] ``utf-8``
+
+/// Keep 2nd case
+type [<StringEnum>] [<RequireQualifiedAccess>] B =
+    | [<CompiledName("utf-8")>] ``utf-8``
+    | Utf8
+
+type [<StringEnum>] [<RequireQualifiedAccess>] C =
+    | [<CompiledName("utf8")>] ``utf8``
+    | [<CompiledName("Utf8")>] Utf8
+    | [<CompiledName("UTF8")>] UTF8
+    | [<CompiledName("utf-8")>] ``utf-8``
+    | [<CompiledName("UTF-8")>] ``UTF-8``
+
+type [<StringEnum>] [<RequireQualifiedAccess>] BufferEncoding =
+    | Ascii
+    | Utf8
+    | [<CompiledName("utf-8")>] ``utf-8``
+    | Utf16le
+    | Ucs2
+    | [<CompiledName("ucs-2")>] ``ucs-2``
+    | Base64
+    | Latin1
+    | Binary
+    | Hex

--- a/test/fsFileTests.fs
+++ b/test/fsFileTests.fs
@@ -815,4 +815,8 @@ let testFsFileLines tsPaths fsPath (f: string list -> unit) =
     // https://github.com/fable-compiler/ts4fable/pull/467
     it "regression #467 NonNullable" <| fun _ ->
         runRegressionTest "#467-NonNullable"
+
+    // https://github.com/fable-compiler/ts5fable/pull/468
+    it "regression #468 String Enum with duplicate name in F#" <| fun _ ->
+        runRegressionTest "#468-string-enum-duplicate-fsharp-name"
 )


### PR DESCRIPTION
```typescript
export type A =
  | "utf8"
  | "utf-8"
```
Currently:
```fsharp
type [<StringEnum>] [<RequireQualifiedAccess>] A =
    | Utf8
    | [<CompiledName("utf-8")>] Utf8
```
-> 
> Duplicate definition of union case 'Utf8'

<br/>

with this PR:
```fsharp
type [<StringEnum>] [<RequireQualifiedAccess>] A =
    | Utf8
    | [<CompiledName("utf-8")>] ``utf-8``
```